### PR TITLE
Show system extensions separately from user extensions

### DIFF
--- a/src/exm-window.blp
+++ b/src/exm-window.blp
@@ -37,9 +37,33 @@ template ExmWindow : Gtk.ApplicationWindow {
 					Adw.Clamp {
 						styles ["clamp"]
 
-						Gtk.ListBox list_box {
-							styles ["boxed-list"]
-							valign: start;
+						Gtk.Box {
+							orientation: vertical;
+							spacing: 10;
+
+							Gtk.Label {
+								styles ["heading"]
+								xalign: 0;
+								margin-top: 20;
+								label: "User-Installed Extensions";
+							}
+
+							Gtk.ListBox user_list_box {
+								styles ["boxed-list"]
+								valign: start;
+							}
+
+							Gtk.Label {
+								styles ["heading"]
+								xalign: 0;
+								margin-top: 20;
+								label: "System Extensions";
+							}
+
+							Gtk.ListBox system_list_box {
+								styles ["boxed-list"]
+								valign: start;
+							}
 						}
 					}
 				};


### PR DESCRIPTION
This makes it clear which extensions the user can remove and which are distributed by the system.

Fixes #12 