### PR TITLE
Add support for Dark Mode

### DIFF
--- a/data/com.mattjakeman.ExtensionManager.gschema.xml
+++ b/data/com.mattjakeman.ExtensionManager.gschema.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist gettext-domain="extension-manager">
-	<schema id="com.mattjakeman.ExtensionManager" path="/com/mattjakeman/ExtensionManager/">
-	</schema>
+  <schema id="com.mattjakeman.ExtensionManager" path="/com/mattjakeman/ExtensionManager/">
+    <key name="style-variant" type="s">
+      <choices>
+        <choice value="use-default"/>
+        <choice value="force-light"/>
+        <choice value="force-dark"/>
+      </choices>
+      <default>'use-default'</default>
+      <summary>Colour Scheme Preference</summary>
+      <description>Whether to follow the system colour scheme or force either light or dark mode.</description>
+    </key>
+  </schema>
 </schemalist>

--- a/src/exm-window.blp
+++ b/src/exm-window.blp
@@ -109,6 +109,24 @@ template ExmWindow : Gtk.ApplicationWindow {
 
 menu primary_menu {
   section {
+    submenu {
+      label: _("Theme");
+      item {
+        label: _("Follow System");
+        action: "app.style-variant";
+        target: "use-default";
+      }
+      item {
+        label: _("Light");
+        action: "app.style-variant";
+        target: "force-light";
+      }
+      item {
+        label: _("Dark");
+        action: "app.style-variant";
+        target: "force-dark";
+      }
+    }
     item {
       label: _("Keyboard Shortcuts");
       action: "win.show-help-overlay";

--- a/src/exm.gresource.xml
+++ b/src/exm.gresource.xml
@@ -5,8 +5,10 @@
     <file>gtk/help-overlay.ui</file>
     <file>style.css</file>
     <file>icons/plugin.png</file>
-    <file preprocess="xml-stripblanks">icons/globe-symbolic.svg</file>
-    <file preprocess="xml-stripblanks">icons/puzzle-piece-symbolic.svg</file>
-    <file preprocess="xml-stripblanks">icons/settings-symbolic.svg</file>
+  </gresource>
+  <gresource prefix="/com/mattjakeman/ExtensionManager/icons/scalable/actions">
+    <file alias="globe-symbolic.svg" preprocess="xml-stripblanks">icons/globe-symbolic.svg</file>
+    <file alias="puzzle-piece-symbolic.svg" preprocess="xml-stripblanks">icons/puzzle-piece-symbolic.svg</file>
+    <file alias="settings-symbolic.svg" preprocess="xml-stripblanks">icons/settings-symbolic.svg</file>
   </gresource>
 </gresources>


### PR DESCRIPTION
 - Let the user override the system dark preference from within the app.
 - Properly support dark mode by making sure symbolic icons are recoloured correctly.

Fixes #7 

Some images:
![Installed Page](https://user-images.githubusercontent.com/12368711/149526194-26737d28-16a2-4ea3-9de4-8d6835dded21.png)
![Browse Page](https://user-images.githubusercontent.com/12368711/149526247-7a25ecac-1c98-4799-9ffb-65504a278586.png)
![In-App Theme Selector](https://user-images.githubusercontent.com/12368711/149526537-7bf91192-b1f6-4bdc-bcfc-50223b6153b6.png)

