### PR TITLE
Only trigger search once browse tab is loaded

### DIFF
--- a/src/exm-window.blp
+++ b/src/exm-window.blp
@@ -78,6 +78,7 @@ template ExmWindow : Gtk.ApplicationWindow {
 					Adw.StatusPage {
 						title: _("Search for extensions");
 						description: _("Enter a keyword to search 'extensions.gnome.org' for GNOME Shell Extensions.");
+						valign: start;
 
 						child: Adw.Clamp {
 							styles ["clamp"]
@@ -87,6 +88,9 @@ template ExmWindow : Gtk.ApplicationWindow {
 
 								Gtk.SearchEntry search_entry {
 									placeholder-text: _("e.g. \"Blur my Shell\"");
+
+									// Hook for triggering initial search
+									realize => on_search_entry_realize();
 								}
 
 								Gtk.ListBox search_results {

--- a/src/exm-window.c
+++ b/src/exm-window.c
@@ -50,19 +50,6 @@ struct _ExmWindow
 
 G_DEFINE_TYPE (ExmWindow, exm_window, GTK_TYPE_APPLICATION_WINDOW)
 
-static void
-exm_window_class_init (ExmWindowClass *klass)
-{
-    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
-
-    gtk_widget_class_set_template_from_resource (widget_class, "/com/mattjakeman/ExtensionManager/exm-window.ui");
-    gtk_widget_class_bind_template_child (widget_class, ExmWindow, header_bar);
-    gtk_widget_class_bind_template_child (widget_class, ExmWindow, user_list_box);
-    gtk_widget_class_bind_template_child (widget_class, ExmWindow, system_list_box);
-    gtk_widget_class_bind_template_child (widget_class, ExmWindow, search_entry);
-    gtk_widget_class_bind_template_child (widget_class, ExmWindow, search_results);
-}
-
 static gboolean
 extension_state_set (GtkSwitch    *toggle,
                      gboolean      state,
@@ -411,6 +398,32 @@ update_system_extensions_list (ExmWindow *self)
 }
 
 static void
+on_search_entry_realize (GtkSearchEntry *search_entry)
+{
+    ExmWindow *self;
+
+    self = EXM_WINDOW (gtk_widget_get_root (GTK_WIDGET (search_entry)));
+
+    // Fire off a default search
+    search (self, "");
+}
+
+static void
+exm_window_class_init (ExmWindowClass *klass)
+{
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+
+    gtk_widget_class_set_template_from_resource (widget_class, "/com/mattjakeman/ExtensionManager/exm-window.ui");
+    gtk_widget_class_bind_template_child (widget_class, ExmWindow, header_bar);
+    gtk_widget_class_bind_template_child (widget_class, ExmWindow, user_list_box);
+    gtk_widget_class_bind_template_child (widget_class, ExmWindow, system_list_box);
+    gtk_widget_class_bind_template_child (widget_class, ExmWindow, search_entry);
+    gtk_widget_class_bind_template_child (widget_class, ExmWindow, search_results);
+
+    gtk_widget_class_bind_template_callback (widget_class, on_search_entry_realize);
+}
+
+static void
 exm_window_init (ExmWindow *self)
 {
     gtk_widget_init_template (GTK_WIDGET (self));
@@ -436,7 +449,4 @@ exm_window_init (ExmWindow *self)
                       "search-changed",
                       G_CALLBACK (on_search_changed),
                       self);
-
-    // Fire off a default search
-    search (self, "");
 }


### PR DESCRIPTION
Adds a callback to the search entry which triggers the default search. This should avoid extraneous calls to extensions.gnome.org where they are not necessary. For example, for users who open the application only to manage local extensions.

Part of #33