### PR TITLE
Add global extension toggle

### DIFF
--- a/src/exm-window.blp
+++ b/src/exm-window.blp
@@ -19,6 +19,9 @@ template ExmWindow : Gtk.ApplicationWindow {
       icon-name: "open-menu-symbolic";
       menu-model: primary_menu;
     }
+
+    [end]
+    Gtk.Switch global_toggle {}
   }
 
   Gtk.Box {

--- a/src/exm-window.c
+++ b/src/exm-window.c
@@ -47,6 +47,7 @@ struct _ExmWindow
     GtkSearchEntry      *search_entry;
     GtkListBox          *search_results;
     GtkStack            *search_stack;
+    GtkSwitch           *global_toggle;
 };
 
 G_DEFINE_TYPE (ExmWindow, exm_window, GTK_TYPE_APPLICATION_WINDOW)
@@ -444,6 +445,7 @@ exm_window_class_init (ExmWindowClass *klass)
     gtk_widget_class_bind_template_child (widget_class, ExmWindow, search_entry);
     gtk_widget_class_bind_template_child (widget_class, ExmWindow, search_results);
     gtk_widget_class_bind_template_child (widget_class, ExmWindow, search_stack);
+    gtk_widget_class_bind_template_child (widget_class, ExmWindow, global_toggle);
 
     gtk_widget_class_bind_template_callback (widget_class, on_search_entry_realize);
 }
@@ -477,6 +479,12 @@ exm_window_init (ExmWindow *self)
                               "items-changed",
                               G_CALLBACK (refresh_search),
                               self);
+
+    g_object_bind_property (self->manager,
+                            "extensions-enabled",
+                            self->global_toggle,
+                            "state",
+                            G_BINDING_BIDIRECTIONAL|G_BINDING_SYNC_CREATE);
 
     g_signal_connect (self->search_entry,
                       "search-changed",

--- a/src/exm-window.c
+++ b/src/exm-window.c
@@ -482,6 +482,18 @@ exm_window_init (ExmWindow *self)
 
     g_object_bind_property (self->manager,
                             "extensions-enabled",
+                            self->user_list_box,
+                            "sensitive",
+                            G_BINDING_SYNC_CREATE);
+
+    g_object_bind_property (self->manager,
+                            "extensions-enabled",
+                            self->system_list_box,
+                            "sensitive",
+                            G_BINDING_SYNC_CREATE);
+
+    g_object_bind_property (self->manager,
+                            "extensions-enabled",
                             self->global_toggle,
                             "state",
                             G_BINDING_BIDIRECTIONAL|G_BINDING_SYNC_CREATE);


### PR DESCRIPTION
 - Adds a toggle which globally enables/disables shell extensions.
 - When extensions are globally disabled, the list boxes are made insensitive.

This might not be the most desirable behaviour (e.g. a user may wish to disable extensions globally, then uninstall some while extensions are off). However this is better than having no toggle at all, and is a good first step.

Fixes #11 

Depends on #37 and #38 