### PR TITLE
The big GUI refactor

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -2,7 +2,12 @@ data/com.mattjakeman.ExtensionManager.desktop.in
 data/com.mattjakeman.ExtensionManager.appdata.xml.in
 data/com.mattjakeman.ExtensionManager.gschema.xml
 src/exm-application.c
+src/exm-browse-page.blp
+src/exm-extension-row.blp
+src/exm-installed-page.blp
+src/exm-search-row.blp
+src/exm-search-row.c
 src/exm-window.blp
-src/main.c
 src/exm-window.c
+src/main.c
 src/gtk/help-overlay.blp

--- a/po/extension-manager.pot
+++ b/po/extension-manager.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: extension-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-12 22:44+1300\n"
+"POT-Creation-Date: 2022-01-17 17:16+1300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -41,6 +41,16 @@ msgstr ""
 msgid "Manage the extensions you already have installed"
 msgstr ""
 
+#: data/com.mattjakeman.ExtensionManager.gschema.xml:11
+msgid "Colour Scheme Preference"
+msgstr ""
+
+#: data/com.mattjakeman.ExtensionManager.gschema.xml:12
+msgid ""
+"Whether to follow the system colour scheme or force either light or dark "
+"mode."
+msgstr ""
+
 #: src/exm-application.c:111
 msgid ""
 "A very simple tool for browsing, downloading, and managing GNOME shell "
@@ -51,57 +61,73 @@ msgstr ""
 msgid "Project Homepage"
 msgstr ""
 
-#: src/exm-window.blp:33 src/exm-window.c:332
-msgid "Installed"
-msgstr ""
-
-#: src/exm-window.blp:48
-msgid "User-Installed Extensions"
-msgstr ""
-
-#: src/exm-window.blp:60
-msgid "System Extensions"
-msgstr ""
-
-#: src/exm-window.blp:74
-msgid "Browse"
-msgstr ""
-
-#: src/exm-window.blp:79
+#: src/exm-browse-page.blp:7
 msgid "Search for extensions"
 msgstr ""
 
-#: src/exm-window.blp:80
+#: src/exm-browse-page.blp:8
 msgid ""
 "Enter a keyword to search 'extensions.gnome.org' for GNOME Shell Extensions."
 msgstr ""
 
-#: src/exm-window.blp:89
+#: src/exm-browse-page.blp:18
 msgid "e.g. \"Blur my Shell\""
 msgstr ""
 
-#: src/exm-window.blp:113
-msgid "Keyboard Shortcuts"
-msgstr ""
-
-#: src/exm-window.blp:117
-msgid "About Extension Manager"
-msgstr ""
-
-#: src/exm-window.c:127
-msgid "Are you sure you want to uninstall?"
-msgstr ""
-
-#: src/exm-window.c:188
+#: src/exm-extension-row.blp:34
 msgid "Remove"
 msgstr ""
 
-#: src/exm-window.c:323
+#: src/exm-installed-page.blp:17
+msgid "User-Installed Extensions"
+msgstr ""
+
+#: src/exm-installed-page.blp:29
+msgid "System Extensions"
+msgstr ""
+
+#: src/exm-search-row.blp:32
 msgid "Go to Page"
 msgstr ""
 
-#: src/exm-window.c:326
+#: src/exm-search-row.blp:36
 msgid "Install"
+msgstr ""
+
+#: src/exm-search-row.c:188 src/exm-window.blp:36
+msgid "Installed"
+msgstr ""
+
+#: src/exm-window.blp:44
+msgid "Browse"
+msgstr ""
+
+#: src/exm-window.blp:61
+msgid "Theme"
+msgstr ""
+
+#: src/exm-window.blp:63
+msgid "Follow System"
+msgstr ""
+
+#: src/exm-window.blp:68
+msgid "Light"
+msgstr ""
+
+#: src/exm-window.blp:73
+msgid "Dark"
+msgstr ""
+
+#: src/exm-window.blp:79
+msgid "Keyboard Shortcuts"
+msgstr ""
+
+#: src/exm-window.blp:83
+msgid "About Extension Manager"
+msgstr ""
+
+#: src/exm-window.c:178
+msgid "Are you sure you want to uninstall?"
 msgstr ""
 
 #: src/gtk/help-overlay.blp:11

--- a/src/exm-browse-page.blp
+++ b/src/exm-browse-page.blp
@@ -1,0 +1,47 @@
+using Gtk 4.0;
+using Adw 1;
+
+template ExmBrowsePage : Gtk.Widget {
+	Gtk.ScrolledWindow {
+		Adw.StatusPage {
+			title: _("Search for extensions");
+			description: _("Enter a keyword to search 'extensions.gnome.org' for GNOME Shell Extensions.");
+			valign: start;
+
+			child: Adw.Clamp {
+				styles ["clamp"]
+
+				Gtk.Box {
+					orientation: vertical;
+
+					Gtk.SearchEntry search_entry {
+						placeholder-text: _("e.g. \"Blur my Shell\"");
+
+						// Hook for triggering initial search
+						// TODO: Re-enable this once blueprint-compiler!4 is merged
+						// realize => on_search_entry_realize();
+					}
+
+					Gtk.Stack search_stack {
+						Gtk.StackPage {
+							name: "page_spinner";
+							child: Gtk.Spinner {
+								valign: start;
+								halign: center;
+								spinning: true;
+							};
+						}
+
+						Gtk.StackPage {
+							name: "page_results";
+							child: Gtk.ListBox search_results {
+								styles ["boxed-list"]
+								valign: start;
+							};
+						}
+					}
+				}
+			};
+		}
+	}
+}

--- a/src/exm-browse-page.c
+++ b/src/exm-browse-page.c
@@ -9,8 +9,6 @@
 
 #include "web/model/exm-search-result.h"
 
-#include <glib/gi18n.h>
-
 struct _ExmBrowsePage
 {
     GtkWidget parent_instance;

--- a/src/exm-browse-page.c
+++ b/src/exm-browse-page.c
@@ -1,0 +1,341 @@
+#include "exm-browse-page.h"
+
+#include "local/exm-manager.h"
+
+#include "web/exm-search-provider.h"
+#include "web/exm-image-resolver.h"
+
+#include "web/model/exm-search-result.h"
+
+#include <glib/gi18n.h>
+
+struct _ExmBrowsePage
+{
+    GtkWidget parent_instance;
+
+    ExmSearchProvider *search;
+    ExmImageResolver *resolver;
+    ExmManager *manager;
+
+    GListModel *search_results_model;
+
+    // Template Widgets
+    GtkSearchEntry      *search_entry;
+    GtkListBox          *search_results;
+    GtkStack            *search_stack;
+};
+
+G_DEFINE_FINAL_TYPE (ExmBrowsePage, exm_browse_page, GTK_TYPE_WIDGET)
+
+enum {
+    PROP_0,
+    PROP_MANAGER,
+    N_PROPS
+};
+
+static GParamSpec *properties [N_PROPS];
+
+ExmBrowsePage *
+exm_browse_page_new (void)
+{
+    return g_object_new (EXM_TYPE_BROWSE_PAGE, NULL);
+}
+
+static void
+exm_browse_page_finalize (GObject *object)
+{
+    ExmBrowsePage *self = (ExmBrowsePage *)object;
+
+    G_OBJECT_CLASS (exm_browse_page_parent_class)->finalize (object);
+}
+
+static void
+exm_browse_page_get_property (GObject    *object,
+                              guint       prop_id,
+                              GValue     *value,
+                              GParamSpec *pspec)
+{
+    ExmBrowsePage *self = EXM_BROWSE_PAGE (object);
+
+    switch (prop_id)
+    {
+    case PROP_MANAGER:
+        g_value_set_object (value, self->manager);
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+exm_browse_page_set_property (GObject      *object,
+                              guint         prop_id,
+                              const GValue *value,
+                              GParamSpec   *pspec)
+{
+    ExmBrowsePage *self = EXM_BROWSE_PAGE (object);
+
+    switch (prop_id)
+    {
+    case PROP_MANAGER:
+        self->manager = g_value_get_object (value);
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+on_image_loaded (GObject      *source,
+                 GAsyncResult *res,
+                 GtkImage     *target)
+{
+    GError *error = NULL;
+    GdkTexture *texture = exm_image_resolver_resolve_finish (EXM_IMAGE_RESOLVER (source),
+                                                             res, &error);
+    if (error)
+    {
+        // TODO: Properly log this
+        g_critical ("%s\n", error->message);
+        return;
+    }
+
+    gtk_image_set_from_paintable (target, GDK_PAINTABLE (texture));
+}
+
+static GtkWidget *
+create_thumbnail (ExmImageResolver *resolver,
+                  const gchar      *icon_uri)
+{
+    GtkWidget *icon;
+
+    icon = gtk_image_new ();
+    gtk_widget_set_valign (icon, GTK_ALIGN_CENTER);
+    gtk_widget_set_halign (icon, GTK_ALIGN_CENTER);
+
+    // Set to default icon
+    gtk_image_set_from_resource (GTK_IMAGE (icon), "/com/mattjakeman/ExtensionManager/icons/plugin.png");
+
+    // If not the default icon, lookup and lazily replace
+    // TODO: There are some outstanding threading issues so avoid downloading for now
+    /*if (strcmp (icon_uri, "/static/images/plugin.png") != 0)
+    {
+        exm_image_resolver_resolve_async (resolver, icon_uri, NULL,
+                                          (GAsyncReadyCallback) on_image_loaded,
+                                          icon);
+    }*/
+
+    return icon;
+}
+
+static void
+install_remote (GtkButton   *button,
+                const gchar *uuid)
+{
+    gtk_widget_activate_action (GTK_WIDGET (button),
+                                "ext.install",
+                                "s", uuid);
+}
+
+static GtkWidget *
+search_widget_factory (ExmSearchResult *result,
+                       ExmBrowsePage   *self)
+{
+    GtkWidget *row;
+    GtkWidget *box;
+    GtkWidget *description_label;
+    GtkWidget *button_box;
+    GtkWidget *install_btn;
+    GtkWidget *link_btn;
+    GtkWidget *icon;
+    GtkWidget *screenshot;
+
+    gchar *uri;
+
+    gchar *uuid, *name, *creator, *icon_uri, *screenshot_uri, *link, *description;
+    g_object_get (result,
+                  "uuid", &uuid,
+                  "name", &name,
+                  "creator", &creator,
+                  "icon", &icon_uri,
+                  "screenshot", &screenshot_uri,
+                  "link", &link,
+                  "description", &description,
+                  NULL);
+
+    name = g_markup_escape_text (name, -1);
+    uri = g_strdup_printf ("https://extensions.gnome.org/%s", link);
+
+    row = adw_expander_row_new ();
+
+    adw_preferences_row_set_title (ADW_PREFERENCES_ROW (row), name);
+    adw_expander_row_set_subtitle (ADW_EXPANDER_ROW (row), creator);
+
+    icon = create_thumbnail (self->resolver, icon_uri);
+    adw_expander_row_add_prefix (ADW_EXPANDER_ROW (row), icon);
+
+    box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
+    gtk_widget_add_css_class (box, "content");
+    adw_expander_row_add_row (ADW_EXPANDER_ROW (row), box);
+
+    description_label = gtk_label_new (description);
+    gtk_label_set_xalign (GTK_LABEL (description_label), 0);
+    gtk_label_set_wrap (GTK_LABEL (description_label), GTK_WRAP_WORD);
+    gtk_widget_add_css_class (description_label, "description");
+    gtk_box_append (GTK_BOX (box), description_label);
+
+    // TODO: This should be on-demand otherwise we're downloading far too often
+    /*screenshot = gtk_image_new ();
+    exm_image_resolver_resolve_async (self->resolver, screenshot_uri, NULL, (GAsyncReadyCallback)on_image_loaded, screenshot);
+    gtk_box_append (GTK_BOX (box), screenshot);*/
+
+    button_box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
+    gtk_widget_set_halign (button_box, GTK_ALIGN_END);
+    gtk_box_append (GTK_BOX (box), button_box);
+
+    link_btn = gtk_link_button_new_with_label (uri, _("Go to Page"));
+    gtk_box_append (GTK_BOX (button_box), link_btn);
+
+    install_btn = gtk_button_new_with_label (_("Install"));
+    g_signal_connect (install_btn, "clicked", G_CALLBACK (install_remote), uuid);
+    gtk_box_append (GTK_BOX (button_box), install_btn);
+
+    if (exm_manager_is_installed_uuid (self->manager, uuid))
+    {
+        gtk_button_set_label (GTK_BUTTON (install_btn), _("Installed"));
+        gtk_widget_set_sensitive (install_btn, FALSE);
+    }
+
+    return row;
+}
+
+static void
+refresh_search (ExmBrowsePage *self)
+{
+    if (!self->manager)
+        return;
+
+    gtk_list_box_bind_model (self->search_results, self->search_results_model,
+                             (GtkListBoxCreateWidgetFunc) search_widget_factory,
+                             g_object_ref (self), g_object_unref);
+
+    // Show Loading Indicator
+    gtk_stack_set_visible_child_name (self->search_stack, "page_results");
+}
+
+static void
+on_search_result (GObject       *source,
+                  GAsyncResult  *res,
+                  ExmBrowsePage *self)
+{
+    GError *error = NULL;
+
+    self->search_results_model = exm_search_provider_query_finish (EXM_SEARCH_PROVIDER (source), res, &error);
+
+    refresh_search (self);
+}
+
+static void
+search (ExmBrowsePage *self,
+        const gchar   *query)
+{
+    // Show Loading Indicator
+    gtk_stack_set_visible_child_name (self->search_stack, "page_spinner");
+
+    exm_search_provider_query_async (self->search, query, NULL,
+                                     (GAsyncReadyCallback) on_search_result,
+                                     self);
+}
+
+static void
+on_search_changed (GtkSearchEntry *search_entry,
+                   ExmBrowsePage  *self)
+{
+    const char *query = gtk_editable_get_text (GTK_EDITABLE (search_entry));
+    search (self, query);
+}
+
+static void
+on_search_entry_realize (GtkSearchEntry *search_entry,
+                         ExmBrowsePage  *self)
+{
+    // Fire off a default search
+    search (self, "");
+}
+
+static void
+on_bind_manager (ExmBrowsePage *self)
+{
+    GListModel *user_ext_model;
+    GListModel *system_ext_model;
+
+    g_object_get (self->manager,
+                  "user-extensions", &user_ext_model,
+                  "system-extensions", &system_ext_model,
+                  NULL);
+
+    g_signal_connect_swapped (user_ext_model,
+                              "items-changed",
+                              G_CALLBACK (refresh_search),
+                              self);
+
+    g_signal_connect_swapped (system_ext_model,
+                              "items-changed",
+                              G_CALLBACK (refresh_search),
+                              self);
+
+    refresh_search (self);
+}
+
+static void
+exm_browse_page_class_init (ExmBrowsePageClass *klass)
+{
+    GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+    object_class->finalize = exm_browse_page_finalize;
+    object_class->get_property = exm_browse_page_get_property;
+    object_class->set_property = exm_browse_page_set_property;
+
+    properties [PROP_MANAGER]
+        = g_param_spec_object ("manager",
+                               "Manager",
+                               "Manager",
+                               EXM_TYPE_MANAGER,
+                               G_PARAM_READWRITE);
+
+    g_object_class_install_properties (object_class, N_PROPS, properties);
+
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+
+    gtk_widget_class_set_template_from_resource (widget_class, "/com/mattjakeman/ExtensionManager/exm-browse-page.ui");
+    gtk_widget_class_bind_template_child (widget_class, ExmBrowsePage, search_entry);
+    gtk_widget_class_bind_template_child (widget_class, ExmBrowsePage, search_results);
+    gtk_widget_class_bind_template_child (widget_class, ExmBrowsePage, search_stack);
+
+    gtk_widget_class_bind_template_callback (widget_class, on_search_entry_realize);
+
+    gtk_widget_class_set_layout_manager_type (widget_class, GTK_TYPE_BIN_LAYOUT);
+}
+
+static void
+exm_browse_page_init (ExmBrowsePage *self)
+{
+    gtk_widget_init_template (GTK_WIDGET (self));
+
+    self->search = exm_search_provider_new ();
+
+    g_signal_connect (self->search_entry,
+                      "search-changed",
+                      G_CALLBACK (on_search_changed),
+                      self);
+
+    g_signal_connect (self->search_entry,
+                      "realize",
+                      G_CALLBACK (on_search_entry_realize),
+                      self);
+
+    g_signal_connect (self,
+                      "notify::manager",
+                      G_CALLBACK (on_bind_manager),
+                      NULL);
+}

--- a/src/exm-browse-page.c
+++ b/src/exm-browse-page.c
@@ -180,7 +180,9 @@ search_widget_factory (ExmSearchResult *result,
 
     description_label = gtk_label_new (description);
     gtk_label_set_xalign (GTK_LABEL (description_label), 0);
-    gtk_label_set_wrap (GTK_LABEL (description_label), GTK_WRAP_WORD);
+    gtk_label_set_wrap (GTK_LABEL (description_label), GTK_WRAP_WORD_CHAR);
+    // This seems to fix a strange wrapping error?
+    gtk_label_set_wrap_mode (GTK_LABEL (description_label), PANGO_WRAP_WORD_CHAR);
     gtk_widget_add_css_class (description_label, "description");
     gtk_box_append (GTK_BOX (box), description_label);
 

--- a/src/exm-browse-page.h
+++ b/src/exm-browse-page.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <gtk/gtk.h>
+#include <adwaita.h>
+
+G_BEGIN_DECLS
+
+#define EXM_TYPE_BROWSE_PAGE (exm_browse_page_get_type())
+
+G_DECLARE_FINAL_TYPE (ExmBrowsePage, exm_browse_page, EXM, BROWSE_PAGE, GtkWidget)
+
+ExmBrowsePage *exm_browse_page_new (void);
+void exm_browse_page_refresh (ExmBrowsePage *self);
+
+G_END_DECLS

--- a/src/exm-extension-row.blp
+++ b/src/exm-extension-row.blp
@@ -1,0 +1,44 @@
+using Gtk 4.0;
+using Adw 1;
+
+template ExmExtensionRow : Adw.ExpanderRow {
+	// title: lookup 'display-name';
+	// subtitle: lookup 'uuid';
+
+	[action]
+	Gtk.Switch ext_toggle {
+		valign: center;
+		halign: center;
+
+		// state-set => on_state_toggled();
+	}
+
+	[action]
+	Gtk.Button prefs_btn {
+		icon-name: "settings-symbolic";
+		valign: center;
+		halign: center;
+
+		// clicked => on_open_prefs();
+	}
+
+	Gtk.Label description_label {
+		styles ["content"]
+
+		// label: lookup 'description';
+		use-markup: false;
+		xalign: 0;
+		wrap-mode: word;
+		wrap: true;
+	}
+
+	Gtk.Button remove_btn {
+		styles ["destructive-action"]
+
+		label: _("Remove");
+		valign: center;
+		halign: end;
+
+		// clicked => on_remove();
+	}
+}

--- a/src/exm-extension-row.blp
+++ b/src/exm-extension-row.blp
@@ -2,15 +2,13 @@ using Gtk 4.0;
 using Adw 1;
 
 template ExmExtensionRow : Adw.ExpanderRow {
-	// title: lookup 'display-name';
-	// subtitle: lookup 'uuid';
 
 	[action]
 	Gtk.Switch ext_toggle {
 		valign: center;
 		halign: center;
 
-		// state-set => on_state_toggled();
+		action-name: 'row.state-set';
 	}
 
 	[action]
@@ -19,14 +17,12 @@ template ExmExtensionRow : Adw.ExpanderRow {
 		valign: center;
 		halign: center;
 
-		// clicked => on_open_prefs();
+		action-name: 'row.open-prefs';
 	}
 
 	Gtk.Label description_label {
 		styles ["content"]
 
-		// label: lookup 'description';
-		use-markup: false;
 		xalign: 0;
 		wrap-mode: word;
 		wrap: true;
@@ -39,6 +35,6 @@ template ExmExtensionRow : Adw.ExpanderRow {
 		valign: center;
 		halign: end;
 
-		// clicked => on_remove();
+		action-name: 'row.remove';
 	}
 }

--- a/src/exm-extension-row.c
+++ b/src/exm-extension-row.c
@@ -73,6 +73,7 @@ exm_extension_row_set_property (GObject      *object,
         self->extension = g_value_get_object (value);
         if (self->extension)
         {
+            // TODO: Bind here, rather than in constructed()
             g_object_get (self->extension,
                           "uuid", &self->uuid,
                           NULL);

--- a/src/exm-extension-row.c
+++ b/src/exm-extension-row.c
@@ -4,7 +4,10 @@ struct _ExmExtensionRow
 {
     AdwExpanderRow parent_instance;
 
+    GSimpleActionGroup *action_group;
+
     ExmExtension *extension;
+    gchar *uuid;
 
     GtkButton *remove_btn;
     GtkButton *prefs_btn;
@@ -68,40 +71,33 @@ exm_extension_row_set_property (GObject      *object,
     {
     case PROP_EXTENSION:
         self->extension = g_value_get_object (value);
+        if (self->extension)
+        {
+            g_object_get (self->extension,
+                          "uuid", &self->uuid,
+                          NULL);
+        }
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
 }
 
-static gboolean
-on_state_toggled (GtkSwitch *toggle,
-                  gboolean   state,
-                  gchar     *uuid)
+void
+update_enable_state (GObject         *self,
+                     GParamSpec      *pspec,
+                     ExmExtensionRow *row)
 {
-    gtk_widget_activate_action (GTK_WIDGET (toggle),
-                                "ext.state-set",
-                                "(sb)", uuid, state);
+    // We update the state of the action without activating it. If we activate
+    // it, then it will go back to gnome-shell and explicitly enable/disable
+    // the extension. We do not want this behaviour as it messes with the global
+    // extension toggle.
 
-    return FALSE;
-}
+    gboolean new_state;
+    g_object_get (self, "enabled", &new_state, NULL);
 
-static void
-on_open_prefs (GtkButton *button,
-               gchar     *uuid)
-{
-    gtk_widget_activate_action (GTK_WIDGET (button),
-                                "ext.open-prefs",
-                                "s", uuid);
-}
-
-static void
-on_remove (GtkButton *button,
-           gchar     *uuid)
-{
-    gtk_widget_activate_action (GTK_WIDGET (button),
-                                "ext.remove",
-                                "s", uuid);
+    GAction *action = g_action_map_lookup_action (G_ACTION_MAP (row->action_group), "state-set");
+    g_simple_action_set_state (G_SIMPLE_ACTION (action), g_variant_new_boolean (new_state));
 }
 
 static void
@@ -130,15 +126,19 @@ exm_extension_row_constructed (GObject *object)
     g_object_set (self->prefs_btn, "visible", has_prefs, NULL);
     g_object_set (self->remove_btn, "visible", is_user, NULL);
 
-    // TODO: Use a property binding for this
-    g_object_set (self->ext_toggle, "state", enabled, NULL);
+    // One way binding from extension ("source of truth") to switch
+    g_signal_connect (self->extension, "notify::enabled", G_CALLBACK (update_enable_state), self);
 
-    // TODO: These signal connections can be removed once blueprint-compiler
-    // supports signal object parameters.
-    // (See https://gitlab.gnome.org/jwestman/blueprint-compiler/-/merge_requests/4)
-    g_signal_connect (self->remove_btn, "clicked", G_CALLBACK (on_remove), uuid);
-    g_signal_connect (self->prefs_btn, "clicked", G_CALLBACK (on_open_prefs), uuid);
-    g_signal_connect (self->ext_toggle, "state-set", G_CALLBACK (on_state_toggled), uuid);
+    GAction *action;
+
+    action = g_action_map_lookup_action (G_ACTION_MAP (self->action_group), "state-set");
+    g_simple_action_set_state (G_SIMPLE_ACTION (action), g_variant_new_boolean (enabled));
+
+    action = g_action_map_lookup_action (G_ACTION_MAP (self->action_group), "open-prefs");
+    g_simple_action_set_enabled (G_SIMPLE_ACTION (action), has_prefs);
+
+    action = g_action_map_lookup_action (G_ACTION_MAP (self->action_group), "remove");
+    g_simple_action_set_enabled (G_SIMPLE_ACTION (action), is_user);
 }
 
 static void
@@ -168,14 +168,76 @@ exm_extension_row_class_init (ExmExtensionRowClass *klass)
     gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, prefs_btn);
     gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, remove_btn);
     gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, ext_toggle);
+}
 
-    gtk_widget_class_bind_template_callback (widget_class, on_open_prefs);
-    gtk_widget_class_bind_template_callback (widget_class, on_remove);
-    gtk_widget_class_bind_template_callback (widget_class, on_state_toggled);
+static void
+state_changed (GSimpleAction   *action,
+               GVariant        *new_value,
+               ExmExtensionRow *self)
+{
+    GVariant *variant;
+    gboolean enabled;
+
+    g_return_if_fail (self->extension);
+
+    variant = g_action_get_state (G_ACTION (action));
+    enabled = g_variant_get_boolean (variant);
+
+    gtk_widget_activate_action (GTK_WIDGET (self),
+                                "ext.state-set",
+                                "(sb)", self->uuid, !enabled);
+
+    g_simple_action_set_state (action, new_value);
+}
+
+static void
+open_prefs (GSimpleAction   *action,
+            GVariant        *new_value,
+            ExmExtensionRow *self)
+{
+    g_return_if_fail (self->extension);
+
+    gtk_widget_activate_action (GTK_WIDGET (self),
+                                "ext.open-prefs",
+                                "s", self->uuid);
+}
+
+static void
+uninstall (GSimpleAction   *action,
+           GVariant        *new_value,
+           ExmExtensionRow *self)
+{
+    g_return_if_fail (self->extension);
+
+    gtk_widget_activate_action (GTK_WIDGET (self),
+                                "ext.remove",
+                                "s", self->uuid);
 }
 
 static void
 exm_extension_row_init (ExmExtensionRow *self)
 {
+    GSimpleAction *state_action;
+    GSimpleAction *open_prefs_action;
+    GSimpleAction *remove_action;
+
     gtk_widget_init_template (GTK_WIDGET (self));
+
+    // Define Actions
+    self->action_group = g_simple_action_group_new ();
+
+    state_action = g_simple_action_new_stateful ("state-set", NULL, g_variant_new_boolean (TRUE));
+    g_signal_connect (state_action, "change-state", G_CALLBACK (state_changed), self);
+
+    open_prefs_action = g_simple_action_new ("open-prefs", NULL);
+    g_signal_connect (open_prefs_action, "activate", G_CALLBACK (open_prefs), self);
+
+    remove_action = g_simple_action_new ("remove", NULL);
+    g_signal_connect (remove_action, "activate", G_CALLBACK (uninstall), self);
+
+    g_action_map_add_action (G_ACTION_MAP (self->action_group), G_ACTION (state_action));
+    g_action_map_add_action (G_ACTION_MAP (self->action_group), G_ACTION (open_prefs_action));
+    g_action_map_add_action (G_ACTION_MAP (self->action_group), G_ACTION (remove_action));
+
+    gtk_widget_insert_action_group (GTK_WIDGET (self), "row", G_ACTION_GROUP (self->action_group));
 }

--- a/src/exm-extension-row.c
+++ b/src/exm-extension-row.c
@@ -1,0 +1,181 @@
+#include "exm-extension-row.h"
+
+struct _ExmExtensionRow
+{
+    AdwExpanderRow parent_instance;
+
+    ExmExtension *extension;
+
+    GtkButton *remove_btn;
+    GtkButton *prefs_btn;
+    GtkButton *description_label;
+    GtkSwitch *ext_toggle;
+};
+
+G_DEFINE_FINAL_TYPE (ExmExtensionRow, exm_extension_row, ADW_TYPE_EXPANDER_ROW)
+
+enum {
+    PROP_0,
+    PROP_EXTENSION,
+    N_PROPS
+};
+
+static GParamSpec *properties [N_PROPS];
+
+ExmExtensionRow *
+exm_extension_row_new (ExmExtension *extension)
+{
+    return g_object_new (EXM_TYPE_EXTENSION_ROW,
+                         "extension", extension,
+                         NULL);
+}
+
+static void
+exm_extension_row_finalize (GObject *object)
+{
+    ExmExtensionRow *self = (ExmExtensionRow *)object;
+
+    G_OBJECT_CLASS (exm_extension_row_parent_class)->finalize (object);
+}
+
+static void
+exm_extension_row_get_property (GObject    *object,
+                                guint       prop_id,
+                                GValue     *value,
+                                GParamSpec *pspec)
+{
+    ExmExtensionRow *self = EXM_EXTENSION_ROW (object);
+
+    switch (prop_id)
+    {
+    case PROP_EXTENSION:
+        g_value_set_object (value, self->extension);
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+exm_extension_row_set_property (GObject      *object,
+                                guint         prop_id,
+                                const GValue *value,
+                                GParamSpec   *pspec)
+{
+    ExmExtensionRow *self = EXM_EXTENSION_ROW (object);
+
+    switch (prop_id)
+    {
+    case PROP_EXTENSION:
+        self->extension = g_value_get_object (value);
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static gboolean
+on_state_toggled (GtkSwitch *toggle,
+                  gboolean   state,
+                  gchar     *uuid)
+{
+    gtk_widget_activate_action (GTK_WIDGET (toggle),
+                                "ext.state-set",
+                                "(sb)", uuid, state);
+
+    return FALSE;
+}
+
+static void
+on_open_prefs (GtkButton *button,
+               gchar     *uuid)
+{
+    gtk_widget_activate_action (GTK_WIDGET (button),
+                                "ext.open-prefs",
+                                "s", uuid);
+}
+
+static void
+on_remove (GtkButton *button,
+           gchar     *uuid)
+{
+    gtk_widget_activate_action (GTK_WIDGET (button),
+                                "ext.remove",
+                                "s", uuid);
+}
+
+static void
+exm_extension_row_constructed (GObject *object)
+{
+    // TODO: This big block of property assignments is currently copy/pasted
+    // from ExmExtension. We can replace this with GtkExpression lookups
+    // once blueprint-compiler supports expressions.
+    // (See https://gitlab.gnome.org/jwestman/blueprint-compiler/-/issues/5)
+
+    ExmExtensionRow *self = EXM_EXTENSION_ROW (object);
+
+    gchar *name, *uuid, *description;
+    gboolean enabled, has_prefs, is_user;
+    g_object_get (self->extension,
+                  "display-name", &name,
+                  "uuid", &uuid,
+                  "description", &description,
+                  "enabled", &enabled,
+                  "has-prefs", &has_prefs,
+                  "is-user", &is_user,
+                  NULL);
+
+    g_object_set (self, "title", name, "subtitle", uuid, NULL);
+    g_object_set (self->description_label, "label", description, NULL);
+    g_object_set (self->prefs_btn, "visible", has_prefs, NULL);
+    g_object_set (self->remove_btn, "visible", is_user, NULL);
+
+    // TODO: Use a property binding for this
+    g_object_set (self->ext_toggle, "state", enabled, NULL);
+
+    // TODO: These signal connections can be removed once blueprint-compiler
+    // supports signal object parameters.
+    // (See https://gitlab.gnome.org/jwestman/blueprint-compiler/-/merge_requests/4)
+    g_signal_connect (self->remove_btn, "clicked", G_CALLBACK (on_remove), uuid);
+    g_signal_connect (self->prefs_btn, "clicked", G_CALLBACK (on_open_prefs), uuid);
+    g_signal_connect (self->ext_toggle, "state-set", G_CALLBACK (on_state_toggled), uuid);
+}
+
+static void
+exm_extension_row_class_init (ExmExtensionRowClass *klass)
+{
+    GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+    object_class->finalize = exm_extension_row_finalize;
+    object_class->get_property = exm_extension_row_get_property;
+    object_class->set_property = exm_extension_row_set_property;
+    object_class->constructed = exm_extension_row_constructed;
+
+    properties [PROP_EXTENSION] =
+        g_param_spec_object ("extension",
+                             "Extension",
+                             "Extension",
+                             EXM_TYPE_EXTENSION,
+                             G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY);
+
+    g_object_class_install_properties (object_class, N_PROPS, properties);
+
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+
+    gtk_widget_class_set_template_from_resource (widget_class, "/com/mattjakeman/ExtensionManager/exm-extension-row.ui");
+
+    gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, description_label);
+    gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, prefs_btn);
+    gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, remove_btn);
+    gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, ext_toggle);
+
+    gtk_widget_class_bind_template_callback (widget_class, on_open_prefs);
+    gtk_widget_class_bind_template_callback (widget_class, on_remove);
+    gtk_widget_class_bind_template_callback (widget_class, on_state_toggled);
+}
+
+static void
+exm_extension_row_init (ExmExtensionRow *self)
+{
+    gtk_widget_init_template (GTK_WIDGET (self));
+}

--- a/src/exm-extension-row.h
+++ b/src/exm-extension-row.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <adwaita.h>
+
+#include "local/exm-extension.h"
+
+G_BEGIN_DECLS
+
+#define EXM_TYPE_EXTENSION_ROW (exm_extension_row_get_type())
+
+G_DECLARE_FINAL_TYPE (ExmExtensionRow, exm_extension_row, EXM, EXTENSION_ROW, AdwExpanderRow)
+
+ExmExtensionRow *
+exm_extension_row_new (ExmExtension *extension);
+
+G_END_DECLS

--- a/src/exm-installed-page.blp
+++ b/src/exm-installed-page.blp
@@ -1,0 +1,39 @@
+using Gtk 4.0;
+using Adw 1;
+
+template ExmInstalledPage : Gtk.Widget {
+	Gtk.ScrolledWindow {
+		Adw.Clamp {
+			styles ["clamp"]
+
+			Gtk.Box {
+				orientation: vertical;
+				spacing: 10;
+
+				Gtk.Label {
+					styles ["heading"]
+					xalign: 0;
+					margin-top: 20;
+					label: _("User-Installed Extensions");
+				}
+
+				Gtk.ListBox user_list_box {
+					styles ["boxed-list"]
+					valign: start;
+				}
+
+				Gtk.Label {
+					styles ["heading"]
+					xalign: 0;
+					margin-top: 20;
+					label: _("System Extensions");
+				}
+
+				Gtk.ListBox system_list_box {
+					styles ["boxed-list"]
+					valign: start;
+				}
+			}
+		}
+	}
+}

--- a/src/exm-installed-page.c
+++ b/src/exm-installed-page.c
@@ -1,5 +1,7 @@
 #include "exm-installed-page.h"
 
+#include "exm-extension-row.h"
+
 #include "local/exm-manager.h"
 
 #include <glib/gi18n.h>
@@ -108,63 +110,11 @@ on_remove (GtkButton *button,
 static GtkWidget *
 widget_factory (ExmExtension* extension)
 {
-    GtkWidget *row;
-    GtkWidget *label;
-    GtkWidget *toggle;
-    GtkWidget *prefs;
-    GtkWidget *remove;
+    ExmExtensionRow *row;
 
-    gchar *name, *uuid, *description;
-    gboolean enabled, has_prefs, is_user;
-    g_object_get (extension,
-                  "display-name", &name,
-                  "uuid", &uuid,
-                  "description", &description,
-                  "enabled", &enabled,
-                  "has-prefs", &has_prefs,
-                  "is-user", &is_user,
-                  NULL);
+    row = exm_extension_row_new (extension);
 
-    name = g_markup_escape_text (name, -1);
-
-    row = adw_expander_row_new ();
-
-    adw_preferences_row_set_title (ADW_PREFERENCES_ROW (row), name);
-    adw_expander_row_set_subtitle (ADW_EXPANDER_ROW (row), uuid);
-
-    toggle = gtk_switch_new ();
-    gtk_switch_set_state (GTK_SWITCH (toggle), enabled);
-    gtk_widget_set_valign (toggle, GTK_ALIGN_CENTER);
-    gtk_widget_set_halign (toggle, GTK_ALIGN_CENTER);
-    adw_expander_row_add_action (ADW_EXPANDER_ROW (row), toggle);
-    g_signal_connect (toggle, "state-set", G_CALLBACK (on_state_toggled), uuid);
-
-    if (has_prefs)
-    {
-        prefs = gtk_button_new_from_icon_name ("settings-symbolic");
-        gtk_widget_set_valign (prefs, GTK_ALIGN_CENTER);
-        gtk_widget_set_halign (prefs, GTK_ALIGN_CENTER);
-        g_signal_connect (prefs, "clicked", G_CALLBACK (on_open_prefs), uuid);
-        adw_expander_row_add_action (ADW_EXPANDER_ROW (row), prefs);
-    }
-
-    label = gtk_label_new (description);
-    gtk_label_set_xalign (GTK_LABEL (label), 0);
-    gtk_label_set_wrap (GTK_LABEL (label), GTK_WRAP_WORD);
-    gtk_widget_add_css_class (label, "content");
-    adw_expander_row_add_row (ADW_EXPANDER_ROW (row), label);
-
-    if (is_user)
-    {
-        remove = gtk_button_new_with_label (_("Remove"));
-        gtk_widget_add_css_class (remove, "destructive-action");
-        gtk_widget_set_valign (remove, GTK_ALIGN_CENTER);
-        gtk_widget_set_halign (remove, GTK_ALIGN_END);
-        g_signal_connect (remove, "clicked", G_CALLBACK (on_remove), uuid);
-        adw_expander_row_add_row (ADW_EXPANDER_ROW (row), remove);
-    }
-
-    return row;
+    return GTK_WIDGET (row);
 }
 
 static void

--- a/src/exm-installed-page.c
+++ b/src/exm-installed-page.c
@@ -1,0 +1,251 @@
+#include "exm-installed-page.h"
+
+#include "local/exm-manager.h"
+
+#include <glib/gi18n.h>
+
+struct _ExmInstalledPage
+{
+    GtkWidget parent_instance;
+
+    ExmManager *manager;
+
+    // Template Widgets
+    GtkListBox          *user_list_box;
+    GtkListBox          *system_list_box;
+};
+
+G_DEFINE_FINAL_TYPE (ExmInstalledPage, exm_installed_page, GTK_TYPE_WIDGET)
+
+enum {
+    PROP_0,
+    PROP_MANAGER,
+    N_PROPS
+};
+
+static GParamSpec *properties [N_PROPS];
+
+ExmInstalledPage *
+exm_installed_page_new (void)
+{
+    return g_object_new (EXM_TYPE_INSTALLED_PAGE, NULL);
+}
+
+static void
+exm_installed_page_finalize (GObject *object)
+{
+    ExmInstalledPage *self = (ExmInstalledPage *)object;
+
+    G_OBJECT_CLASS (exm_installed_page_parent_class)->finalize (object);
+}
+
+static void
+exm_installed_page_get_property (GObject    *object,
+                                 guint       prop_id,
+                                 GValue     *value,
+                                 GParamSpec *pspec)
+{
+    ExmInstalledPage *self = EXM_INSTALLED_PAGE (object);
+
+    switch (prop_id)
+    {
+    case PROP_MANAGER:
+        g_value_set_object (value, self->manager);
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+exm_installed_page_set_property (GObject      *object,
+                                 guint         prop_id,
+                                 const GValue *value,
+                                 GParamSpec   *pspec)
+{
+    ExmInstalledPage *self = EXM_INSTALLED_PAGE (object);
+
+    switch (prop_id)
+    {
+    case PROP_MANAGER:
+        self->manager = g_value_get_object (value);
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static gboolean
+on_state_toggled (GtkSwitch *toggle,
+                  gboolean   state,
+                  gchar     *uuid)
+{
+    gtk_widget_activate_action (GTK_WIDGET (toggle),
+                                "ext.state-set",
+                                "(sb)", uuid, state);
+
+    return FALSE;
+}
+
+static void
+on_open_prefs (GtkButton *button,
+               gchar     *uuid)
+{
+    gtk_widget_activate_action (GTK_WIDGET (button),
+                                "ext.open-prefs",
+                                "s", uuid);
+}
+
+static void
+on_remove (GtkButton *button,
+           gchar     *uuid)
+{
+    gtk_widget_activate_action (GTK_WIDGET (button),
+                                "ext.remove",
+                                "s", uuid);
+}
+
+static GtkWidget *
+widget_factory (ExmExtension* extension)
+{
+    GtkWidget *row;
+    GtkWidget *label;
+    GtkWidget *toggle;
+    GtkWidget *prefs;
+    GtkWidget *remove;
+
+    gchar *name, *uuid, *description;
+    gboolean enabled, has_prefs, is_user;
+    g_object_get (extension,
+                  "display-name", &name,
+                  "uuid", &uuid,
+                  "description", &description,
+                  "enabled", &enabled,
+                  "has-prefs", &has_prefs,
+                  "is-user", &is_user,
+                  NULL);
+
+    name = g_markup_escape_text (name, -1);
+
+    row = adw_expander_row_new ();
+
+    adw_preferences_row_set_title (ADW_PREFERENCES_ROW (row), name);
+    adw_expander_row_set_subtitle (ADW_EXPANDER_ROW (row), uuid);
+
+    toggle = gtk_switch_new ();
+    gtk_switch_set_state (GTK_SWITCH (toggle), enabled);
+    gtk_widget_set_valign (toggle, GTK_ALIGN_CENTER);
+    gtk_widget_set_halign (toggle, GTK_ALIGN_CENTER);
+    adw_expander_row_add_action (ADW_EXPANDER_ROW (row), toggle);
+    g_signal_connect (toggle, "state-set", G_CALLBACK (on_state_toggled), uuid);
+
+    if (has_prefs)
+    {
+        prefs = gtk_button_new_from_icon_name ("settings-symbolic");
+        gtk_widget_set_valign (prefs, GTK_ALIGN_CENTER);
+        gtk_widget_set_halign (prefs, GTK_ALIGN_CENTER);
+        g_signal_connect (prefs, "clicked", G_CALLBACK (on_open_prefs), uuid);
+        adw_expander_row_add_action (ADW_EXPANDER_ROW (row), prefs);
+    }
+
+    label = gtk_label_new (description);
+    gtk_label_set_xalign (GTK_LABEL (label), 0);
+    gtk_label_set_wrap (GTK_LABEL (label), GTK_WRAP_WORD);
+    gtk_widget_add_css_class (label, "content");
+    adw_expander_row_add_row (ADW_EXPANDER_ROW (row), label);
+
+    if (is_user)
+    {
+        remove = gtk_button_new_with_label (_("Remove"));
+        gtk_widget_add_css_class (remove, "destructive-action");
+        gtk_widget_set_valign (remove, GTK_ALIGN_CENTER);
+        gtk_widget_set_halign (remove, GTK_ALIGN_END);
+        g_signal_connect (remove, "clicked", G_CALLBACK (on_remove), uuid);
+        adw_expander_row_add_row (ADW_EXPANDER_ROW (row), remove);
+    }
+
+    return row;
+}
+
+static void
+bind_list_box (GtkListBox *list_box,
+               GListModel *model)
+{
+    GtkExpression *expression;
+    GtkStringSorter *sorter;
+    GtkSortListModel *sorted_model;
+
+    // Sort alphabetically
+    expression = gtk_property_expression_new (EXM_TYPE_EXTENSION, NULL, "display-name");
+    sorter = gtk_string_sorter_new (expression);
+    sorted_model = gtk_sort_list_model_new (model, GTK_SORTER (sorter));
+
+    gtk_list_box_bind_model (list_box, G_LIST_MODEL (sorted_model),
+                             (GtkListBoxCreateWidgetFunc) widget_factory,
+                             NULL, NULL);
+}
+
+static void
+on_bind_manager (ExmInstalledPage *self)
+{
+    GListModel *user_ext_model;
+    GListModel *system_ext_model;
+
+    g_object_get (self->manager,
+                  "user-extensions", &user_ext_model,
+                  "system-extensions", &system_ext_model,
+                  NULL);
+
+    bind_list_box (self->user_list_box, user_ext_model);
+    bind_list_box (self->system_list_box, system_ext_model);
+
+    g_object_bind_property (self->manager,
+                            "extensions-enabled",
+                            self->user_list_box,
+                            "sensitive",
+                            G_BINDING_SYNC_CREATE);
+
+    g_object_bind_property (self->manager,
+                            "extensions-enabled",
+                            self->system_list_box,
+                            "sensitive",
+                            G_BINDING_SYNC_CREATE);
+}
+
+static void
+exm_installed_page_class_init (ExmInstalledPageClass *klass)
+{
+    GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+    object_class->finalize = exm_installed_page_finalize;
+    object_class->get_property = exm_installed_page_get_property;
+    object_class->set_property = exm_installed_page_set_property;
+
+    properties [PROP_MANAGER]
+        = g_param_spec_object ("manager",
+                               "Manager",
+                               "Manager",
+                               EXM_TYPE_MANAGER,
+                               G_PARAM_READWRITE);
+
+    g_object_class_install_properties (object_class, N_PROPS, properties);
+
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+
+    gtk_widget_class_set_template_from_resource (widget_class, "/com/mattjakeman/ExtensionManager/exm-installed-page.ui");
+    gtk_widget_class_bind_template_child (widget_class, ExmInstalledPage, user_list_box);
+    gtk_widget_class_bind_template_child (widget_class, ExmInstalledPage, system_list_box);
+
+    gtk_widget_class_set_layout_manager_type (widget_class, GTK_TYPE_BIN_LAYOUT);
+}
+
+static void
+exm_installed_page_init (ExmInstalledPage *self)
+{
+    gtk_widget_init_template (GTK_WIDGET (self));
+
+    g_signal_connect (self,
+                      "notify::manager",
+                      G_CALLBACK (on_bind_manager),
+                      NULL);
+}

--- a/src/exm-installed-page.c
+++ b/src/exm-installed-page.c
@@ -4,8 +4,6 @@
 
 #include "local/exm-manager.h"
 
-#include <glib/gi18n.h>
-
 struct _ExmInstalledPage
 {
     GtkWidget parent_instance;

--- a/src/exm-installed-page.h
+++ b/src/exm-installed-page.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <gtk/gtk.h>
+#include <adwaita.h>
+
+G_BEGIN_DECLS
+
+#define EXM_TYPE_INSTALLED_PAGE (exm_installed_page_get_type())
+
+G_DECLARE_FINAL_TYPE (ExmInstalledPage, exm_installed_page, EXM, INSTALLED_PAGE, GtkWidget)
+
+ExmInstalledPage *exm_installed_page_new (void);
+
+G_END_DECLS

--- a/src/exm-search-row.blp
+++ b/src/exm-search-row.blp
@@ -1,0 +1,40 @@
+using Gtk 4.0;
+using Adw 1;
+
+template ExmSearchRow : Adw.ExpanderRow {
+
+	[prefix]
+	Gtk.Image icon {
+		valign: center;
+		halign: center;
+
+		resource: "/com/mattjakeman/ExtensionManager/icons/plugin.png";
+	}
+
+	Gtk.Box {
+		styles ["content"]
+
+		orientation: vertical;
+
+		Gtk.Label description_label {
+			styles ["description"]
+
+			xalign: 0;
+			wrap: true;
+			wrap-mode: word_char;
+		}
+
+		Gtk.Box {
+			orientation: horizontal;
+			halign: end;
+
+			Gtk.LinkButton link_btn {
+				label: _("Go to Page");
+			}
+
+			Gtk.Button install_btn {
+				label: _("Install");
+			}
+		}
+	}
+}

--- a/src/exm-search-row.c
+++ b/src/exm-search-row.c
@@ -1,0 +1,234 @@
+#include "exm-search-row.h"
+
+#include <glib/gi18n.h>
+
+struct _ExmSearchRow
+{
+    AdwExpanderRow parent_instance;
+
+    ExmSearchResult *search_result;
+    gboolean is_installed;
+    gchar *uuid;
+
+    GtkLabel *description_label;
+    GtkLinkButton *link_btn;
+    GtkButton *install_btn;
+};
+
+G_DEFINE_FINAL_TYPE (ExmSearchRow, exm_search_row, ADW_TYPE_EXPANDER_ROW)
+
+enum {
+    PROP_0,
+    PROP_SEARCH_RESULT,
+    PROP_IS_INSTALLED,
+    N_PROPS
+};
+
+static GParamSpec *properties [N_PROPS];
+
+ExmSearchRow *
+exm_search_row_new (ExmSearchResult *search_result,
+                    gboolean         is_installed)
+{
+    return g_object_new (EXM_TYPE_SEARCH_ROW,
+                         "search-result", search_result,
+                         "is-installed", is_installed,
+                         NULL);
+}
+
+static void
+exm_search_row_finalize (GObject *object)
+{
+    ExmSearchRow *self = (ExmSearchRow *)object;
+
+    G_OBJECT_CLASS (exm_search_row_parent_class)->finalize (object);
+}
+
+static void
+exm_search_row_get_property (GObject    *object,
+                             guint       prop_id,
+                             GValue     *value,
+                             GParamSpec *pspec)
+{
+    ExmSearchRow *self = EXM_SEARCH_ROW (object);
+
+    switch (prop_id)
+    {
+    case PROP_SEARCH_RESULT:
+        g_value_set_object (value, self->search_result);
+        break;
+    case PROP_IS_INSTALLED:
+        g_value_set_boolean (value, self->is_installed);
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+exm_search_row_set_property (GObject      *object,
+                             guint         prop_id,
+                             const GValue *value,
+                             GParamSpec   *pspec)
+{
+    ExmSearchRow *self = EXM_SEARCH_ROW (object);
+
+    switch (prop_id)
+    {
+    case PROP_SEARCH_RESULT:
+        self->search_result = g_value_get_object (value);
+        if (self->search_result)
+        {
+            // TODO: Bind here, rather than in constructed()
+            g_object_get (self->search_result,
+                          "uuid", &self->uuid,
+                          NULL);
+        }
+        break;
+    case PROP_IS_INSTALLED:
+        self->is_installed = g_value_get_boolean (value);
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+/*static void
+on_image_loaded (GObject      *source,
+                 GAsyncResult *res,
+                 GtkImage     *target)
+{
+    GError *error = NULL;
+    GdkTexture *texture = exm_image_resolver_resolve_finish (EXM_IMAGE_RESOLVER (source),
+                                                             res, &error);
+    if (error)
+    {
+        // TODO: Properly log this
+        g_critical ("%s\n", error->message);
+        return;
+    }
+
+    gtk_image_set_from_paintable (target, GDK_PAINTABLE (texture));
+}
+
+static GtkWidget *
+create_thumbnail (ExmImageResolver *resolver,
+                  const gchar      *icon_uri)
+{
+    GtkWidget *icon;
+
+    icon = gtk_image_new ();
+    gtk_widget_set_valign (icon, GTK_ALIGN_CENTER);
+    gtk_widget_set_halign (icon, GTK_ALIGN_CENTER);
+
+    // Set to default icon
+    gtk_image_set_from_resource (GTK_IMAGE (icon), "/com/mattjakeman/ExtensionManager/icons/plugin.png");
+
+    // If not the default icon, lookup and lazily replace
+    // TODO: There are some outstanding threading issues so avoid downloading for now
+    if (strcmp (icon_uri, "/static/images/plugin.png") != 0)
+    {
+        exm_image_resolver_resolve_async (resolver, icon_uri, NULL,
+                                          (GAsyncReadyCallback) on_image_loaded,
+                                          icon);
+    }
+
+    return icon;
+}*/
+
+static void
+install_remote (GtkButton   *button,
+                const gchar *uuid)
+{
+    gtk_widget_activate_action (GTK_WIDGET (button),
+                                "ext.install",
+                                "s", uuid);
+}
+
+static void
+exm_search_row_constructed (GObject *object)
+{
+    // TODO: This big block of property assignments is currently copy/pasted
+    // from ExmExtension. We can replace this with GtkExpression lookups
+    // once blueprint-compiler supports expressions.
+    // (See https://gitlab.gnome.org/jwestman/blueprint-compiler/-/issues/5)
+
+    ExmSearchRow *self = EXM_SEARCH_ROW (object);
+
+    gchar *uri;
+
+    gchar *uuid, *name, *creator, *icon_uri, *screenshot_uri, *link, *description;
+    g_object_get (self->search_result,
+                  "uuid", &uuid,
+                  "name", &name,
+                  "creator", &creator,
+                  "icon", &icon_uri,
+                  "screenshot", &screenshot_uri,
+                  "link", &link,
+                  "description", &description,
+                  NULL);
+
+    name = g_markup_escape_text (name, -1);
+    uri = g_strdup_printf ("https://extensions.gnome.org/%s", link);
+
+    // icon = create_thumbnail (self->resolver, icon_uri);
+    // adw_expander_row_add_prefix (ADW_EXPANDER_ROW (row), icon);
+
+    // TODO: This should be on-demand otherwise we're downloading far too often
+    // screenshot = gtk_image_new ();
+    // exm_image_resolver_resolve_async (self->resolver, screenshot_uri, NULL, (GAsyncReadyCallback)on_image_loaded, screenshot);
+    // gtk_box_append (GTK_BOX (box), screenshot);
+
+    g_object_set (self, "title", name, "subtitle", creator, NULL);
+    gtk_label_set_label (self->description_label, description);
+    gtk_link_button_set_uri (self->link_btn, uri);
+
+    if (self->is_installed)
+    {
+        gtk_button_set_label (self->install_btn, _("Installed"));
+        gtk_widget_set_sensitive (GTK_WIDGET (self->install_btn), FALSE);
+    }
+
+    g_signal_connect (self->install_btn, "clicked", G_CALLBACK (install_remote), uuid);
+}
+
+static void
+exm_search_row_class_init (ExmSearchRowClass *klass)
+{
+    GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+    object_class->finalize = exm_search_row_finalize;
+    object_class->get_property = exm_search_row_get_property;
+    object_class->set_property = exm_search_row_set_property;
+    object_class->constructed = exm_search_row_constructed;
+
+    properties [PROP_SEARCH_RESULT] =
+        g_param_spec_object ("search-result",
+                             "Search Result",
+                             "Search Result",
+                             EXM_TYPE_SEARCH_RESULT,
+                             G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY);
+
+    properties [PROP_IS_INSTALLED] =
+        g_param_spec_boolean ("is-installed",
+                              "Is Installed",
+                              "Is Installed",
+                              FALSE,
+                              G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY);
+
+    g_object_class_install_properties (object_class, N_PROPS, properties);
+
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+
+    gtk_widget_class_set_template_from_resource (widget_class, "/com/mattjakeman/ExtensionManager/exm-search-row.ui");
+
+    gtk_widget_class_bind_template_child (widget_class, ExmSearchRow, description_label);
+    gtk_widget_class_bind_template_child (widget_class, ExmSearchRow, link_btn);
+    gtk_widget_class_bind_template_child (widget_class, ExmSearchRow, install_btn);
+}
+
+static void
+exm_search_row_init (ExmSearchRow *self)
+{
+    gtk_widget_init_template (GTK_WIDGET (self));
+}

--- a/src/exm-search-row.h
+++ b/src/exm-search-row.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <adwaita.h>
+
+#include "web/model/exm-search-result.h"
+
+G_BEGIN_DECLS
+
+#define EXM_TYPE_SEARCH_ROW (exm_search_row_get_type())
+
+G_DECLARE_FINAL_TYPE (ExmSearchRow, exm_search_row, EXM, SEARCH_ROW, AdwExpanderRow)
+
+ExmSearchRow *exm_search_row_new (ExmSearchResult *search_result,
+                                  gboolean         is_installed);
+
+G_END_DECLS

--- a/src/exm-window.blp
+++ b/src/exm-window.blp
@@ -31,45 +31,12 @@ template ExmWindow : Gtk.ApplicationWindow {
   		vexpand: true;
   		hexpand: true;
 
-			Adw.ViewStackPage {
+			 Adw.ViewStackPage {
 				name: "installed";
 				title: _("Installed");
 				icon-name: "puzzle-piece-symbolic";
 
-				child: Gtk.ScrolledWindow {
-					Adw.Clamp {
-						styles ["clamp"]
-
-						Gtk.Box {
-							orientation: vertical;
-							spacing: 10;
-
-							Gtk.Label {
-								styles ["heading"]
-								xalign: 0;
-								margin-top: 20;
-								label: _("User-Installed Extensions");
-							}
-
-							Gtk.ListBox user_list_box {
-								styles ["boxed-list"]
-								valign: start;
-							}
-
-							Gtk.Label {
-								styles ["heading"]
-								xalign: 0;
-								margin-top: 20;
-								label: _("System Extensions");
-							}
-
-							Gtk.ListBox system_list_box {
-								styles ["boxed-list"]
-								valign: start;
-							}
-						}
-					}
-				};
+				child: .ExmInstalledPage installed_page {};
 			}
 
 			Adw.ViewStackPage {
@@ -77,47 +44,7 @@ template ExmWindow : Gtk.ApplicationWindow {
 				title: _("Browse");
 				icon-name: "globe-symbolic";
 
-				child: Gtk.ScrolledWindow {
-					Adw.StatusPage {
-						title: _("Search for extensions");
-						description: _("Enter a keyword to search 'extensions.gnome.org' for GNOME Shell Extensions.");
-						valign: start;
-
-						child: Adw.Clamp {
-							styles ["clamp"]
-
-							Gtk.Box {
-								orientation: vertical;
-
-								Gtk.SearchEntry search_entry {
-									placeholder-text: _("e.g. \"Blur my Shell\"");
-
-									// Hook for triggering initial search
-									realize => on_search_entry_realize();
-								}
-
-								Gtk.Stack search_stack {
-									Gtk.StackPage {
-										name: "page_spinner";
-										child: Gtk.Spinner {
-											valign: start;
-											halign: center;
-											spinning: true;
-										};
-									}
-
-									Gtk.StackPage {
-										name: "page_results";
-										child: Gtk.ListBox search_results {
-											styles ["boxed-list"]
-											valign: start;
-										};
-									}
-								}
-							}
-						};
-					}
-				};
+				child: .ExmBrowsePage browse_page {};
 			}
 		}
 

--- a/src/exm-window.c
+++ b/src/exm-window.c
@@ -119,6 +119,8 @@ extension_state_set (GtkWidget  *widget,
     gchar *uuid;
     gboolean state;
 
+    g_print ("Setting!");
+
     self = EXM_WINDOW (widget);
     g_variant_get (param, "(sb)", &uuid, &state);
 

--- a/src/exm-window.c
+++ b/src/exm-window.c
@@ -19,13 +19,11 @@
 #include "exm-config.h"
 #include "exm-window.h"
 
+#include "exm-browse-page.h"
+#include "exm-installed-page.h"
+
 #include "local/exm-manager.h"
 #include "local/exm-extension.h"
-
-#include "web/exm-search-provider.h"
-#include "web/exm-image-resolver.h"
-
-#include "web/model/exm-search-result.h"
 
 #include <adwaita.h>
 #include <glib/gi18n.h>
@@ -35,47 +33,101 @@ struct _ExmWindow
     GtkApplicationWindow  parent_instance;
 
     ExmManager *manager;
-    ExmSearchProvider *search;
-    ExmImageResolver *resolver;
-
-    GListModel *search_results_model;
 
     /* Template widgets */
     AdwHeaderBar        *header_bar;
-    GtkListBox          *user_list_box;
-    GtkListBox          *system_list_box;
-    GtkSearchEntry      *search_entry;
-    GtkListBox          *search_results;
-    GtkStack            *search_stack;
     GtkSwitch           *global_toggle;
+    ExmBrowsePage       *browse_page;
+    ExmInstalledPage    *installed_page;
 };
 
 G_DEFINE_TYPE (ExmWindow, exm_window, GTK_TYPE_APPLICATION_WINDOW)
 
-static gboolean
-extension_state_set (GtkSwitch    *toggle,
-                     gboolean      state,
-                     ExmExtension *extension)
+enum {
+    PROP_0,
+    PROP_MANAGER,
+    N_PROPS
+};
+
+static GParamSpec *properties [N_PROPS];
+
+static void
+exm_window_finalize (GObject *object)
 {
-    GtkRoot *root = gtk_widget_get_root (GTK_WIDGET (toggle));
-    ExmWindow *self = EXM_WINDOW (root);
+    ExmWindow *self = (ExmWindow *)object;
+
+    G_OBJECT_CLASS (exm_window_parent_class)->finalize (object);
+}
+
+static void
+exm_window_get_property (GObject    *object,
+                         guint       prop_id,
+                         GValue     *value,
+                         GParamSpec *pspec)
+{
+    ExmWindow *self = EXM_WINDOW (object);
+
+    switch (prop_id)
+    {
+    case PROP_MANAGER:
+        g_value_set_object (value, self->manager);
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+exm_window_set_property (GObject      *object,
+                         guint         prop_id,
+                         const GValue *value,
+                         GParamSpec   *pspec)
+{
+    ExmWindow *self = EXM_WINDOW (object);
+
+    switch (prop_id)
+    {
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+extension_open_prefs (GtkWidget  *widget,
+                      const char *action_name,
+                      GVariant   *param)
+{
+    ExmWindow *self;
+    ExmExtension *extension;
+    gchar *uuid;
+
+    self = EXM_WINDOW (widget);
+    g_variant_get (param, "s", &uuid);
+
+    extension = exm_manager_get_by_uuid (self->manager, uuid);
+
+    exm_manager_open_prefs (self->manager, extension);
+}
+
+static void
+extension_state_set (GtkWidget  *widget,
+                     const char *action_name,
+                     GVariant   *param)
+{
+    ExmWindow *self;
+    ExmExtension *extension;
+    gchar *uuid;
+    gboolean state;
+
+    self = EXM_WINDOW (widget);
+    g_variant_get (param, "(sb)", &uuid, &state);
+
+    extension = exm_manager_get_by_uuid (self->manager, uuid);
 
     if (state)
         exm_manager_enable_extension (self->manager, extension);
     else
         exm_manager_disable_extension (self->manager, extension);
-
-    return FALSE;
-}
-
-static void
-extension_open_prefs (GtkButton    *button,
-                      ExmExtension *extension)
-{
-    GtkRoot *root = gtk_widget_get_root (GTK_WIDGET (button));
-    ExmWindow *self = EXM_WINDOW (root);
-
-    exm_manager_open_prefs (self->manager, extension);
 }
 
 typedef struct
@@ -102,11 +154,18 @@ extension_remove_dialog_response (GtkDialog        *dialog,
 }
 
 static void
-extension_remove (GtkButton    *button,
-                  ExmExtension *extension)
+extension_remove (GtkWidget  *widget,
+                  const char *action_name,
+                  GVariant   *param)
 {
-    GtkRoot *root = gtk_widget_get_root (GTK_WIDGET (button));
-    ExmWindow *self = EXM_WINDOW (root);
+    ExmWindow *self;
+    ExmExtension *extension;
+    gchar *uuid;
+
+    self = EXM_WINDOW (widget);
+    g_variant_get (param, "s", &uuid);
+
+    extension = exm_manager_get_by_uuid (self->manager, uuid);
 
     GtkWidget *dlg;
 
@@ -124,72 +183,9 @@ extension_remove (GtkButton    *button,
     gtk_widget_show (dlg);
 }
 
-static GtkWidget *
-widget_factory (ExmExtension* extension)
-{
-    GtkWidget *row;
-    GtkWidget *label;
-    GtkWidget *toggle;
-    GtkWidget *prefs;
-    GtkWidget *remove;
-
-    gchar *name, *uuid, *description;
-    gboolean enabled, has_prefs, is_user;
-    g_object_get (extension,
-                  "display-name", &name,
-                  "uuid", &uuid,
-                  "description", &description,
-                  "enabled", &enabled,
-                  "has-prefs", &has_prefs,
-                  "is-user", &is_user,
-                  NULL);
-
-    name = g_markup_escape_text (name, -1);
-
-    row = adw_expander_row_new ();
-
-    adw_preferences_row_set_title (ADW_PREFERENCES_ROW (row), name);
-    adw_expander_row_set_subtitle (ADW_EXPANDER_ROW (row), uuid);
-
-    toggle = gtk_switch_new ();
-    gtk_switch_set_state (GTK_SWITCH (toggle), enabled);
-    gtk_widget_set_valign (toggle, GTK_ALIGN_CENTER);
-    gtk_widget_set_halign (toggle, GTK_ALIGN_CENTER);
-    adw_expander_row_add_action (ADW_EXPANDER_ROW (row), toggle);
-    g_signal_connect (toggle, "state-set", G_CALLBACK (extension_state_set), extension);
-
-    if (has_prefs)
-    {
-        prefs = gtk_button_new_from_icon_name ("settings-symbolic");
-        gtk_widget_set_valign (prefs, GTK_ALIGN_CENTER);
-        gtk_widget_set_halign (prefs, GTK_ALIGN_CENTER);
-        g_signal_connect (prefs, "clicked", G_CALLBACK (extension_open_prefs), extension);
-        adw_expander_row_add_action (ADW_EXPANDER_ROW (row), prefs);
-    }
-
-    label = gtk_label_new (description);
-    gtk_label_set_xalign (GTK_LABEL (label), 0);
-    gtk_label_set_wrap (GTK_LABEL (label), GTK_WRAP_WORD);
-    gtk_widget_add_css_class (label, "content");
-    adw_expander_row_add_row (ADW_EXPANDER_ROW (row), label);
-
-    if (is_user)
-    {
-        remove = gtk_button_new_with_label (_("Remove"));
-        gtk_widget_add_css_class (remove, "destructive-action");
-        gtk_widget_set_valign (remove, GTK_ALIGN_CENTER);
-        gtk_widget_set_halign (remove, GTK_ALIGN_END);
-        g_signal_connect (remove, "clicked", G_CALLBACK (extension_remove), extension);
-        adw_expander_row_add_row (ADW_EXPANDER_ROW (row), remove);
-    }
-
-    return row;
-}
-
 static void
-on_install_done (GObject      *source,
-                 GAsyncResult *res,
-                 ExmWindow    *self)
+on_install_done (GObject       *source,
+                 GAsyncResult  *res)
 {
     GError *error = NULL;
     if (!exm_manager_install_finish (EXM_MANAGER (source), res, &error) && error)
@@ -200,11 +196,15 @@ on_install_done (GObject      *source,
 }
 
 static void
-install_remote (GtkButton   *button,
-                const gchar *uuid)
+extension_install (GtkWidget  *widget,
+                   const char *action_name,
+                   GVariant   *param)
 {
-    GtkRoot *root = gtk_widget_get_root (GTK_WIDGET (button));
-    ExmWindow *self = EXM_WINDOW (root);
+    ExmWindow *self;
+    gchar *uuid;
+
+    self = EXM_WINDOW (widget);
+    g_variant_get (param, "s", &uuid);
 
     exm_manager_install_async (self->manager, uuid, NULL,
                                (GAsyncReadyCallback) on_install_done,
@@ -212,294 +212,53 @@ install_remote (GtkButton   *button,
 }
 
 static void
-on_image_loaded (GObject      *source,
-                 GAsyncResult *res,
-                 GtkImage     *target)
-{
-    GError *error = NULL;
-    GdkTexture *texture = exm_image_resolver_resolve_finish (EXM_IMAGE_RESOLVER (source),
-                                                             res, &error);
-    if (error)
-    {
-        // TODO: Properly log this
-        g_critical ("%s\n", error->message);
-        return;
-    }
-
-    gtk_image_set_from_paintable (target, GDK_PAINTABLE (texture));
-}
-
-static GtkWidget *
-create_thumbnail (ExmImageResolver *resolver,
-                  const gchar      *icon_uri)
-{
-    GtkWidget *icon;
-
-    icon = gtk_image_new ();
-    gtk_widget_set_valign (icon, GTK_ALIGN_CENTER);
-    gtk_widget_set_halign (icon, GTK_ALIGN_CENTER);
-
-    // Set to default icon
-    gtk_image_set_from_resource (GTK_IMAGE (icon), "/com/mattjakeman/ExtensionManager/icons/plugin.png");
-
-    // If not the default icon, lookup and lazily replace
-    // TODO: There are some outstanding threading issues so avoid downloading for now
-    /*if (strcmp (icon_uri, "/static/images/plugin.png") != 0)
-    {
-        exm_image_resolver_resolve_async (resolver, icon_uri, NULL,
-                                          (GAsyncReadyCallback) on_image_loaded,
-                                          icon);
-    }*/
-
-    return icon;
-}
-
-static GtkWidget *
-search_widget_factory (ExmSearchResult *result,
-                       ExmWindow       *self)
-{
-    GtkWidget *row;
-    GtkWidget *box;
-    GtkWidget *description_label;
-    GtkWidget *button_box;
-    GtkWidget *install_btn;
-    GtkWidget *link_btn;
-    GtkWidget *icon;
-    GtkWidget *screenshot;
-
-    gchar *uri;
-
-    gchar *uuid, *name, *creator, *icon_uri, *screenshot_uri, *link, *description;
-    g_object_get (result,
-                  "uuid", &uuid,
-                  "name", &name,
-                  "creator", &creator,
-                  "icon", &icon_uri,
-                  "screenshot", &screenshot_uri,
-                  "link", &link,
-                  "description", &description,
-                  NULL);
-
-    name = g_markup_escape_text (name, -1);
-    uri = g_strdup_printf ("https://extensions.gnome.org/%s", link);
-
-    row = adw_expander_row_new ();
-
-    adw_preferences_row_set_title (ADW_PREFERENCES_ROW (row), name);
-    adw_expander_row_set_subtitle (ADW_EXPANDER_ROW (row), creator);
-
-    icon = create_thumbnail (self->resolver, icon_uri);
-    adw_expander_row_add_prefix (ADW_EXPANDER_ROW (row), icon);
-
-    box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
-    gtk_widget_add_css_class (box, "content");
-    adw_expander_row_add_row (ADW_EXPANDER_ROW (row), box);
-
-    description_label = gtk_label_new (description);
-    gtk_label_set_xalign (GTK_LABEL (description_label), 0);
-    gtk_label_set_wrap (GTK_LABEL (description_label), GTK_WRAP_WORD);
-    gtk_widget_add_css_class (description_label, "description");
-    gtk_box_append (GTK_BOX (box), description_label);
-
-    // TODO: This should be on-demand otherwise we're downloading far too often
-    /*screenshot = gtk_image_new ();
-    exm_image_resolver_resolve_async (self->resolver, screenshot_uri, NULL, (GAsyncReadyCallback)on_image_loaded, screenshot);
-    gtk_box_append (GTK_BOX (box), screenshot);*/
-
-    button_box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
-    gtk_widget_set_halign (button_box, GTK_ALIGN_END);
-    gtk_box_append (GTK_BOX (box), button_box);
-
-    link_btn = gtk_link_button_new_with_label (uri, _("Go to Page"));
-    gtk_box_append (GTK_BOX (button_box), link_btn);
-
-    install_btn = gtk_button_new_with_label (_("Install"));
-    g_signal_connect (install_btn, "clicked", G_CALLBACK (install_remote), uuid);
-    gtk_box_append (GTK_BOX (button_box), install_btn);
-
-    if (exm_manager_is_installed_uuid (self->manager, uuid))
-    {
-        gtk_button_set_label (GTK_BUTTON (install_btn), _("Installed"));
-        gtk_widget_set_sensitive (install_btn, FALSE);
-    }
-
-    return row;
-}
-
-static void
-refresh_search (ExmWindow *self)
-{
-    gtk_list_box_bind_model (self->search_results, self->search_results_model,
-                             (GtkListBoxCreateWidgetFunc) search_widget_factory,
-                             g_object_ref (self), g_object_unref);
-
-    // Show Loading Indicator
-    gtk_stack_set_visible_child_name (self->search_stack, "page_results");
-}
-
-static void
-on_search_result (GObject      *source,
-                  GAsyncResult *res,
-                  ExmWindow    *self)
-{
-    GError *error = NULL;
-
-    self->search_results_model = exm_search_provider_query_finish (EXM_SEARCH_PROVIDER (source), res, &error);
-
-    refresh_search (self);
-}
-
-static void
-search (ExmWindow *self, const gchar *query)
-{
-    // Show Loading Indicator
-    gtk_stack_set_visible_child_name (self->search_stack, "page_spinner");
-
-    exm_search_provider_query_async (self->search, query, NULL,
-                                     (GAsyncReadyCallback) on_search_result,
-                                     self);
-}
-
-static void
-on_search_changed (GtkSearchEntry *search_entry,
-                   ExmWindow      *self)
-{
-    const char *query = gtk_editable_get_text (GTK_EDITABLE (search_entry));
-    search (self, query);
-}
-
-static void
-update_extensions_list (ExmWindow   *self,
-                        GtkListBox  *list_box,
-                        const gchar *property_name)
-{
-    GListModel *model;
-    GtkExpression *expression;
-    GtkStringSorter *sorter;
-    GtkSortListModel *sorted_model;
-
-    g_object_get (self->manager, property_name, &model, NULL);
-
-    // Sort alphabetically
-    expression = gtk_property_expression_new (EXM_TYPE_EXTENSION, NULL, "display-name");
-    sorter = gtk_string_sorter_new (expression);
-    sorted_model = gtk_sort_list_model_new (model, GTK_SORTER (sorter));
-
-    gtk_list_box_bind_model (list_box, G_LIST_MODEL (sorted_model),
-                             (GtkListBoxCreateWidgetFunc) widget_factory,
-                             NULL, NULL);
-
-    refresh_search (self);
-}
-
-static void
-update_user_extensions_list (ExmWindow *self)
-{
-    update_extensions_list (self, self->user_list_box, "user-extensions");
-}
-
-static void
-update_system_extensions_list (ExmWindow *self)
-{
-    update_extensions_list (self, self->system_list_box, "system-extensions");
-}
-
-static void
-on_search_entry_realize (GtkSearchEntry *search_entry)
-{
-    ExmWindow *self;
-
-    self = EXM_WINDOW (gtk_widget_get_root (GTK_WIDGET (search_entry)));
-
-    // Fire off a default search
-    search (self, "");
-}
-
-static void
-bind_list_box (GtkListBox *list_box,
-               GListModel *model)
-{
-    GtkExpression *expression;
-    GtkStringSorter *sorter;
-    GtkSortListModel *sorted_model;
-
-    // Sort alphabetically
-    expression = gtk_property_expression_new (EXM_TYPE_EXTENSION, NULL, "display-name");
-    sorter = gtk_string_sorter_new (expression);
-    sorted_model = gtk_sort_list_model_new (model, GTK_SORTER (sorter));
-
-    gtk_list_box_bind_model (list_box, G_LIST_MODEL (sorted_model),
-                             (GtkListBoxCreateWidgetFunc) widget_factory,
-                             NULL, NULL);
-}
-
-static void
 exm_window_class_init (ExmWindowClass *klass)
 {
+    GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+    object_class->finalize = exm_window_finalize;
+    object_class->get_property = exm_window_get_property;
+    object_class->set_property = exm_window_set_property;
+
+    properties [PROP_MANAGER]
+        = g_param_spec_object ("manager",
+                               "Manager",
+                               "Manager",
+                               EXM_TYPE_MANAGER,
+                               G_PARAM_READABLE);
+
+    g_object_class_install_properties (object_class, N_PROPS, properties);
+
     GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
 
     gtk_widget_class_set_template_from_resource (widget_class, "/com/mattjakeman/ExtensionManager/exm-window.ui");
     gtk_widget_class_bind_template_child (widget_class, ExmWindow, header_bar);
-    gtk_widget_class_bind_template_child (widget_class, ExmWindow, user_list_box);
-    gtk_widget_class_bind_template_child (widget_class, ExmWindow, system_list_box);
-    gtk_widget_class_bind_template_child (widget_class, ExmWindow, search_entry);
-    gtk_widget_class_bind_template_child (widget_class, ExmWindow, search_results);
-    gtk_widget_class_bind_template_child (widget_class, ExmWindow, search_stack);
     gtk_widget_class_bind_template_child (widget_class, ExmWindow, global_toggle);
+    gtk_widget_class_bind_template_child (widget_class, ExmWindow, installed_page);
+    gtk_widget_class_bind_template_child (widget_class, ExmWindow, browse_page);
 
-    gtk_widget_class_bind_template_callback (widget_class, on_search_entry_realize);
+    // TODO: Refactor ExmWindow into a separate ExmController and supply the
+    // necessary actions/methods/etc in there. A reference to this new object can
+    // then be passed to each page.
+    gtk_widget_class_install_action (widget_class, "ext.install", "s", extension_install);
+    gtk_widget_class_install_action (widget_class, "ext.remove", "s", extension_remove);
+    gtk_widget_class_install_action (widget_class, "ext.state-set", "(sb)", extension_state_set);
+    gtk_widget_class_install_action (widget_class, "ext.open-prefs", "s", extension_open_prefs);
 }
 
 static void
 exm_window_init (ExmWindow *self)
 {
-    GListModel *user_ext_model;
-    GListModel *system_ext_model;
-
     gtk_widget_init_template (GTK_WIDGET (self));
 
     self->manager = exm_manager_new ();
-    self->resolver = exm_image_resolver_new ();
-    self->search = exm_search_provider_new ();
 
-    g_object_get (self->manager,
-                  "user-extensions", &user_ext_model,
-                  "system-extensions", &system_ext_model,
-                  NULL);
-
-    bind_list_box (self->user_list_box, user_ext_model);
-    bind_list_box (self->system_list_box, system_ext_model);
-
-    g_signal_connect_swapped (user_ext_model,
-                              "items-changed",
-                              G_CALLBACK (refresh_search),
-                              self);
-
-    g_signal_connect_swapped (system_ext_model,
-                              "items-changed",
-                              G_CALLBACK (refresh_search),
-                              self);
-
-    g_object_bind_property (self->manager,
-                            "extensions-enabled",
-                            self->user_list_box,
-                            "sensitive",
-                            G_BINDING_SYNC_CREATE);
-
-    g_object_bind_property (self->manager,
-                            "extensions-enabled",
-                            self->system_list_box,
-                            "sensitive",
-                            G_BINDING_SYNC_CREATE);
+    g_object_set (self->installed_page, "manager", self->manager, NULL);
+    g_object_set (self->browse_page, "manager", self->manager, NULL);
 
     g_object_bind_property (self->manager,
                             "extensions-enabled",
                             self->global_toggle,
                             "state",
                             G_BINDING_BIDIRECTIONAL|G_BINDING_SYNC_CREATE);
-
-    g_signal_connect (self->search_entry,
-                      "search-changed",
-                      G_CALLBACK (on_search_changed),
-                      self);
 }

--- a/src/exm.gresource.xml
+++ b/src/exm.gresource.xml
@@ -4,6 +4,7 @@
     <file>exm-window.ui</file>
     <file>exm-installed-page.ui</file>
     <file>exm-browse-page.ui</file>
+    <file>exm-extension-row.ui</file>
     <file>gtk/help-overlay.ui</file>
     <file>style.css</file>
     <file>icons/plugin.png</file>

--- a/src/exm.gresource.xml
+++ b/src/exm.gresource.xml
@@ -5,6 +5,7 @@
     <file>exm-installed-page.ui</file>
     <file>exm-browse-page.ui</file>
     <file>exm-extension-row.ui</file>
+    <file>exm-search-row.ui</file>
     <file>gtk/help-overlay.ui</file>
     <file>style.css</file>
     <file>icons/plugin.png</file>

--- a/src/exm.gresource.xml
+++ b/src/exm.gresource.xml
@@ -2,6 +2,8 @@
 <gresources>
   <gresource prefix="/com/mattjakeman/ExtensionManager">
     <file>exm-window.ui</file>
+    <file>exm-installed-page.ui</file>
+    <file>exm-browse-page.ui</file>
     <file>gtk/help-overlay.ui</file>
     <file>style.css</file>
     <file>icons/plugin.png</file>

--- a/src/local/exm-extension.c
+++ b/src/local/exm-extension.c
@@ -10,6 +10,7 @@ struct _ExmExtension
     gboolean is_user;
     gboolean has_prefs;
     gboolean has_update;
+    gboolean can_change;
 };
 
 G_DEFINE_FINAL_TYPE (ExmExtension, exm_extension, G_TYPE_OBJECT)
@@ -23,28 +24,17 @@ enum {
     PROP_DESCRIPTION,
     PROP_HAS_PREFS,
     PROP_HAS_UPDATE,
+    PROP_CAN_CHANGE,
     N_PROPS
 };
 
 static GParamSpec *properties [N_PROPS];
 
 ExmExtension *
-exm_extension_new (gchar    *uuid,
-                   gchar    *display_name,
-                   gchar    *description,
-                   gboolean  enabled,
-                   gboolean  is_user,
-                   gboolean  has_prefs,
-                   gboolean  has_update)
+exm_extension_new (const gchar *uuid)
 {
     return g_object_new (EXM_TYPE_EXTENSION,
                          "uuid", uuid,
-                         "display-name", display_name,
-                         "description", description,
-                         "enabled", enabled,
-                         "is-user", is_user,
-                         "has-prefs", has_prefs,
-                         "has-update", has_update,
                          NULL);
 }
 
@@ -89,6 +79,9 @@ exm_extension_get_property (GObject    *object,
     case PROP_HAS_UPDATE:
         g_value_set_boolean (value, self->has_update);
         break;
+    case PROP_CAN_CHANGE:
+        g_value_set_boolean (value, self->can_change);
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
@@ -125,6 +118,9 @@ exm_extension_set_property (GObject      *object,
     case PROP_HAS_UPDATE:
         self->has_update = g_value_get_boolean (value);
         break;
+    case PROP_CAN_CHANGE:
+        self->can_change = g_value_get_boolean (value);
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
@@ -151,42 +147,49 @@ exm_extension_class_init (ExmExtensionClass *klass)
                              "Display Name",
                              "Display Name",
                              NULL,
-                             G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY);
+                             G_PARAM_READWRITE);
 
     properties [PROP_DESCRIPTION] =
         g_param_spec_string ("description",
                              "Description",
                              "Description",
                              NULL,
-                             G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY);
+                             G_PARAM_READWRITE);
 
     properties [PROP_ENABLED] =
         g_param_spec_boolean ("enabled",
                               "Enabled",
                               "Enabled",
                               FALSE,
-                              G_PARAM_READWRITE|G_PARAM_CONSTRUCT);
+                              G_PARAM_READWRITE);
 
     properties [PROP_IS_USER] =
         g_param_spec_boolean ("is-user",
                               "Is User",
                               "Is User",
                               FALSE,
-                              G_PARAM_READWRITE|G_PARAM_CONSTRUCT);
+                              G_PARAM_READWRITE);
 
     properties [PROP_HAS_PREFS] =
         g_param_spec_boolean ("has-prefs",
                               "Has Preferences",
                               "Has Preferences",
                               FALSE,
-                              G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY);
+                              G_PARAM_READWRITE);
 
     properties [PROP_HAS_UPDATE] =
         g_param_spec_boolean ("has-update",
                               "Has Update",
                               "Has Update",
                               FALSE,
-                              G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY);
+                              G_PARAM_READWRITE);
+
+    properties [PROP_CAN_CHANGE] =
+        g_param_spec_boolean ("can-change",
+                              "Can Change",
+                              "Can Change",
+                              FALSE,
+                              G_PARAM_READWRITE);
 
     g_object_class_install_properties (object_class, N_PROPS, properties);
 }

--- a/src/local/exm-extension.c
+++ b/src/local/exm-extension.c
@@ -71,9 +71,11 @@ exm_extension_get_property (GObject    *object,
         break;
     case PROP_DISPLAY_NAME:
         g_value_set_string (value, self->display_name);
+        self->display_name = g_markup_escape_text (self->display_name, -1);
         break;
     case PROP_DESCRIPTION:
         g_value_set_string (value, self->description);
+        self->description = g_markup_escape_text (self->description, -1);
         break;
     case PROP_ENABLED:
         g_value_set_boolean (value, self->enabled);

--- a/src/local/exm-extension.h
+++ b/src/local/exm-extension.h
@@ -8,12 +8,6 @@ G_BEGIN_DECLS
 
 G_DECLARE_FINAL_TYPE (ExmExtension, exm_extension, EXM, EXTENSION, GObject)
 
-ExmExtension *exm_extension_new (gchar    *uuid,
-                                 gchar    *display_name,
-                                 gchar    *description,
-                                 gboolean  enabled,
-                                 gboolean  is_user,
-                                 gboolean  has_prefs,
-                                 gboolean  has_update);
+ExmExtension *exm_extension_new (const gchar *uuid);
 
 G_END_DECLS

--- a/src/local/exm-manager.c
+++ b/src/local/exm-manager.c
@@ -222,9 +222,9 @@ exm_manager_open_prefs (ExmManager   *self,
                                                   extension);
 }
 
-static gboolean
-list_model_contains (GListModel  *model,
-                     const gchar *uuid)
+static gpointer
+list_model_get_by_uuid (GListModel  *model,
+                        const gchar *uuid)
 {
     int n_items = g_list_model_get_n_items (model);
     for (int i = 0; i < n_items; i++)
@@ -235,10 +235,32 @@ list_model_contains (GListModel  *model,
         g_object_get (ext, "uuid", &cmp_uuid, NULL);
 
         if (strcmp (uuid, cmp_uuid) == 0)
-            return TRUE;
+            return ext;
     }
 
-    return FALSE;
+    return NULL;
+}
+
+static gboolean
+list_model_contains (GListModel  *model,
+                     const gchar *uuid)
+{
+    return list_model_get_by_uuid (model, uuid) != NULL;
+}
+
+ExmExtension *
+exm_manager_get_by_uuid (ExmManager  *self,
+                         const gchar *uuid)
+{
+    ExmExtension *result = NULL;
+
+    if ((result = list_model_get_by_uuid (self->user_ext_model, uuid)) != NULL)
+        return result;
+
+    if ((result = list_model_get_by_uuid (self->system_ext_model, uuid)) != NULL)
+        return result;
+
+    return NULL;
 }
 
 gboolean

--- a/src/local/exm-manager.c
+++ b/src/local/exm-manager.c
@@ -365,9 +365,9 @@ exm_manager_class_init (ExmManagerClass *klass)
 }
 
 static void
-parse_single_extension (const gchar   *extension_uuid,
+parse_single_extension (ExmExtension **extension,
+                        const gchar   *extension_uuid,
                         GVariantIter  *variant_iter,
-                        ExmExtension **extension,
                         gboolean      *is_user,
                         gboolean      *is_uninstall_operation)
 {
@@ -381,10 +381,21 @@ parse_single_extension (const gchar   *extension_uuid,
     gboolean enabled = FALSE;
     gboolean has_prefs = FALSE;
     gboolean has_update = FALSE;
+    gboolean can_change = TRUE;
 
     *is_user = FALSE;
     *is_uninstall_operation = FALSE;
-    *extension = NULL;
+
+    if (extension && *extension)
+    {
+        const gchar *uuid_cmp;
+        g_object_get (*extension, "uuid", &uuid_cmp, NULL);
+        g_assert (strcmp (extension_uuid, uuid_cmp) == 0);
+    }
+    else
+    {
+        *extension = exm_extension_new (extension_uuid);
+    }
 
     while (g_variant_iter_loop (variant_iter, "{sv}", &prop_name, &prop_value))
     {
@@ -431,9 +442,21 @@ parse_single_extension (const gchar   *extension_uuid,
         {
             g_variant_get (prop_value, "b", &has_update);
         }
+        else if (strcmp (prop_name, "canChange") == 0)
+        {
+            g_variant_get (prop_value, "b", &can_change);
+        }
     }
 
-    *extension = exm_extension_new (uuid, display_name, description, enabled, *is_user, has_prefs, has_update);
+    g_object_set (*extension,
+                  "display-name", display_name,
+                  "description", description,
+                  "enabled", enabled,
+                  "is-user", *is_user,
+                  "has-prefs", has_prefs,
+                  "has-update", has_update,
+                  "can-change", can_change,
+                  NULL);
 
     g_free (uuid);
     g_free (display_name);
@@ -464,9 +487,9 @@ parse_extension_list (GVariant   *exlist,
     while (g_variant_iter_loop (iter, "{sa{sv}}", &exname, &iter2)) {
         gboolean is_user;
         gboolean is_uninstall_operation;
-        ExmExtension *extension;
+        ExmExtension *extension = NULL;
 
-        parse_single_extension (exname, iter2, &extension, &is_user, &is_uninstall_operation);
+        parse_single_extension (&extension, exname, iter2, &is_user, &is_uninstall_operation);
 
         if (is_uninstall_operation)
         {
@@ -544,6 +567,7 @@ on_state_changed (ShellExtensions *object,
 {
     ExmExtension *extension;
     gboolean is_user;
+    gboolean is_new;
     gboolean is_uninstall_operation;
     GListStore *list_store;
 
@@ -555,12 +579,22 @@ on_state_changed (ShellExtensions *object,
 
     g_print ("%s\n", g_variant_print (arg_state, TRUE));
 
+    // This is NULL if it does not exist
+    extension = exm_manager_get_by_uuid (self, arg_uuid);
+    is_new = (extension == NULL);
+
     GVariantIter *iter;
     g_variant_get (arg_state, "a{sv}", &iter);
-    parse_single_extension (arg_uuid, iter, &extension, &is_user, &is_uninstall_operation);
+    parse_single_extension (&extension, arg_uuid, iter, &is_user, &is_uninstall_operation);
     g_variant_iter_free (iter);
 
     list_store = G_LIST_STORE (is_user ? self->user_ext_model : self->system_ext_model);
+
+    if (is_new)
+    {
+        g_list_store_append (list_store, extension);
+        return;
+    }
 
     if (is_uninstall_operation)
     {
@@ -570,13 +604,6 @@ on_state_changed (ShellExtensions *object,
 
         return;
     }
-
-    // Try replace in list store
-    if (replace_extension_in_list_store (list_store, extension))
-        return;
-
-    // Append to list store
-    g_list_store_append (list_store, extension);
 }
 
 static void

--- a/src/local/exm-manager.h
+++ b/src/local/exm-manager.h
@@ -17,6 +17,7 @@ void exm_manager_disable_extension (ExmManager *manager, ExmExtension *extension
 void exm_manager_remove_extension (ExmManager *self, ExmExtension *extension);
 void exm_manager_open_prefs (ExmManager *self, ExmExtension *extension);
 gboolean exm_manager_is_installed_uuid (ExmManager *self, const gchar *uuid);
+ExmExtension *exm_manager_get_by_uuid (ExmManager  *self, const gchar *uuid);
 
 void exm_manager_install_async (ExmManager          *self,
                                 const gchar         *uuid,

--- a/src/meson.build
+++ b/src/meson.build
@@ -2,8 +2,13 @@ exm_sources = [
   'main.c',
   'exm-window.c',
   'exm-application.c',
+
+  # Installed Page
+  'exm-installed-page.c',
+  'exm-extension-row.c',
+
+  # Browse Page
   'exm-browse-page.c',
-  'exm-installed-page.c'
 ]
 
 exm_deps = [
@@ -23,7 +28,8 @@ blueprints = custom_target('blueprints',
     'gtk/help-overlay.blp',
     'exm-window.blp',
     'exm-installed-page.blp',
-    'exm-browse-page.blp'
+    'exm-browse-page.blp',
+    'exm-extension-row.blp'
   ),
   output: '.',
   command: [find_program('blueprint-compiler'), 'batch-compile', '@OUTPUT@', '@CURRENT_SOURCE_DIR@', '@INPUT@'],

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,7 +1,9 @@
 exm_sources = [
   'main.c',
   'exm-window.c',
-  'exm-application.c'
+  'exm-application.c',
+  'exm-browse-page.c',
+  'exm-installed-page.c'
 ]
 
 exm_deps = [
@@ -19,7 +21,9 @@ subdir('web')
 blueprints = custom_target('blueprints',
   input: files(
     'gtk/help-overlay.blp',
-    'exm-window.blp'
+    'exm-window.blp',
+    'exm-installed-page.blp',
+    'exm-browse-page.blp'
   ),
   output: '.',
   command: [find_program('blueprint-compiler'), 'batch-compile', '@OUTPUT@', '@CURRENT_SOURCE_DIR@', '@INPUT@'],

--- a/src/meson.build
+++ b/src/meson.build
@@ -9,6 +9,7 @@ exm_sources = [
 
   # Browse Page
   'exm-browse-page.c',
+  'exm-search-row.c'
 ]
 
 exm_deps = [
@@ -29,7 +30,8 @@ blueprints = custom_target('blueprints',
     'exm-window.blp',
     'exm-installed-page.blp',
     'exm-browse-page.blp',
-    'exm-extension-row.blp'
+    'exm-extension-row.blp',
+    'exm-search-row.blp'
   ),
   output: '.',
   command: [find_program('blueprint-compiler'), 'batch-compile', '@OUTPUT@', '@CURRENT_SOURCE_DIR@', '@INPUT@'],


### PR DESCRIPTION
 - [X] Refactors ExmWindow into multiple types
 - [X] Uses GTK Actions for performing tasks
 - [x] Replace widget factory methods with UI files
     - [x] Uses blueprints for the search results
     - [x] Uses blueprints for the installed view
 - [x] Update list widgets granularly
 - [x] Update potfiles with new strings
     - Six strings added, none removed
 - [x] ~~Split out task code from ExmWindow into new ExmController~~ (Deferred)

This will make the GUI more maintainable and paves the way for #3.

Incidentally, it is also significantly faster as the listbox is not recreated each time an update occurs.