### PR TITLE
Add support for sorting search results

### DIFF
--- a/src/exm-browse-page.blp
+++ b/src/exm-browse-page.blp
@@ -14,12 +14,25 @@ template ExmBrowsePage : Gtk.Widget {
 				Gtk.Box {
 					orientation: vertical;
 
-					Gtk.SearchEntry search_entry {
-						placeholder-text: _("e.g. \"Blur my Shell\"");
+					Gtk.Box {
+						styles ["linked"]
 
-						// Hook for triggering initial search
-						// TODO: Re-enable this once blueprint-compiler!4 is merged
-						// realize => on_search_entry_realize();
+						Gtk.SearchEntry search_entry {
+							hexpand: true;
+							placeholder-text: _("e.g. \"Blur my Shell\"");
+
+							// Hook for triggering initial search
+							// TODO: Re-enable this once blueprint-compiler!4 is merged
+							// realize => on_search_entry_realize();
+						}
+
+						// Keep the same order as the ExmSearchSort enum
+						Gtk.DropDown search_dropdown {
+							model: StringList {
+								// Translators: dropdown items for sorting search results
+								strings [_("Popularity"), _("Downloads"), _("Recent"), _("Name")]
+							};
+						}
 					}
 
 					Gtk.Stack search_stack {

--- a/src/web/exm-search-provider.c
+++ b/src/web/exm-search-provider.c
@@ -76,17 +76,38 @@ parse_search_results (GBytes  *bytes,
     return NULL;
 }
 
+const gchar *
+get_sort_string (ExmSearchSort sort_type)
+{
+    switch (sort_type)
+    {
+    case EXM_SEARCH_SORT_DOWNLOADS:
+        return "downloads";
+    case EXM_SEARCH_SORT_RECENT:
+        return "recent";
+    case EXM_SEARCH_SORT_NAME:
+        return "name";
+    case EXM_SEARCH_SORT_POPULARITY:
+    default:
+        return "popularity";
+    }
+}
+
 void
 exm_search_provider_query_async (ExmSearchProvider   *self,
                                  const gchar         *query,
+                                 ExmSearchSort        sort_type,
                                  GCancellable        *cancellable,
                                  GAsyncReadyCallback  callback,
                                  gpointer             user_data)
 {
-    // Query https://extensions.gnome.org/extension-query/?search={%s}
+    // Query https://extensions.gnome.org/extension-query/?search={%s}&sort={%s}
 
-    gchar *url;
-    url = g_strdup_printf ("https://extensions.gnome.org/extension-query/?search=%s", query);
+    const gchar *url;
+    const gchar *sort;
+
+    sort = get_sort_string (sort_type);
+    url = g_strdup_printf ("https://extensions.gnome.org/extension-query/?search=%s&sort=%s", query, sort);
 
     exm_request_handler_request_async (EXM_REQUEST_HANDLER (self),
                                        url,

--- a/src/web/exm-search-provider.h
+++ b/src/web/exm-search-provider.h
@@ -11,11 +11,20 @@ G_BEGIN_DECLS
 
 G_DECLARE_FINAL_TYPE (ExmSearchProvider, exm_search_provider, EXM, SEARCH_PROVIDER, ExmRequestHandler)
 
+typedef enum
+{
+    EXM_SEARCH_SORT_POPULARITY = 0,
+    EXM_SEARCH_SORT_DOWNLOADS = 1,
+    EXM_SEARCH_SORT_RECENT = 2,
+    EXM_SEARCH_SORT_NAME = 3
+} ExmSearchSort;
+
 ExmSearchProvider *exm_search_provider_new (void);
 
 void
 exm_search_provider_query_async (ExmSearchProvider   *self,
                                  const gchar         *query,
+                                 ExmSearchSort        sort_type,
                                  GCancellable        *cancellable,
                                  GAsyncReadyCallback  callback,
                                  gpointer             user_data);


### PR DESCRIPTION
Allow filtering search results by:
 - Popularity
 - Downloads
 - Name
 - Recent

Just like the extensions.gnome.org website

Part of #33 