### PR TITLE
Cleanup console output

### DIFF
--- a/src/exm-window.c
+++ b/src/exm-window.c
@@ -119,8 +119,6 @@ extension_state_set (GtkWidget  *widget,
     gchar *uuid;
     gboolean state;
 
-    g_print ("Setting!");
-
     self = EXM_WINDOW (widget);
     g_variant_get (param, "(sb)", &uuid, &state);
 

--- a/src/local/exm-manager.c
+++ b/src/local/exm-manager.c
@@ -397,9 +397,11 @@ parse_single_extension (ExmExtension **extension,
         *extension = exm_extension_new (extension_uuid);
     }
 
+    g_debug ("Found extension '%s' with properties:\n", uuid);
+
     while (g_variant_iter_loop (variant_iter, "{sv}", &prop_name, &prop_value))
     {
-        // g_print (" - Property: %s=%s\n", prop_name, g_variant_print(prop_value, 0));
+        g_debug (" - Property: %s=%s\n", prop_name, g_variant_print(prop_value, 0));
 
         // Compare with DBus property names
         if (strcmp (prop_name, "uuid") == 0)
@@ -571,13 +573,11 @@ on_state_changed (ShellExtensions *object,
     gboolean is_uninstall_operation;
     GListStore *list_store;
 
-    g_print ("State Changed for extension '%s'\n", arg_uuid);
+    g_debug ("State Changed for extension '%s'\n", arg_uuid);
 
     // Parse the new extension state and update only that element in
     // the list model. This will automatically update any bound
     // listboxes or listviews.
-
-    g_print ("%s\n", g_variant_print (arg_state, TRUE));
 
     // This is NULL if it does not exist
     extension = exm_manager_get_by_uuid (self, arg_uuid);
@@ -613,7 +613,7 @@ on_status_changed (ShellExtensions *object,
                    const gchar     *arg_error,
                    ExmManager      *self)
 {
-    g_print ("Status Changed (Unhandled) for extension '%s'\n", arg_uuid);
+    g_debug ("Status Changed (Unhandled) for extension '%s'\n", arg_uuid);
 
     // TODO: What's this for?
 }

--- a/src/web/exm-search-provider.c
+++ b/src/web/exm-search-provider.c
@@ -38,7 +38,8 @@ parse_search_results (GBytes  *bytes,
 
     data = g_bytes_get_data (bytes, &length);
 
-    g_print ("%s\n", (gchar *)data);
+    g_debug ("Received JSON search results:\n");
+    g_debug ("%s\n", (gchar *)data);
 
     parser = json_parser_new ();
     if (json_parser_load_from_data (parser, data, length, &error))
@@ -63,7 +64,6 @@ parse_search_results (GBytes  *bytes,
         {
             GObject *result;
 
-            g_print ("Extension Found!\n");
             result = json_gobject_deserialize (EXM_TYPE_SEARCH_RESULT, l->data);
 
             g_list_store_append (store, result);

--- a/src/web/model/exm-shell-version-map.c
+++ b/src/web/model/exm-shell-version-map.c
@@ -1,0 +1,74 @@
+#include "exm-shell-version-map.h"
+
+struct _ExmShellVersionMap
+{
+    GObject parent_instance;
+};
+
+G_DEFINE_FINAL_TYPE (ExmShellVersionMap, exm_shell_version_map, G_TYPE_OBJECT)
+
+enum {
+    PROP_0,
+    N_PROPS
+};
+
+static GParamSpec *properties [N_PROPS];
+
+ExmShellVersionMap *
+exm_shell_version_map_new (void)
+{
+    return g_object_new (EXM_TYPE_SHELL_VERSION_MAP, NULL);
+}
+
+static void
+exm_shell_version_map_finalize (GObject *object)
+{
+    ExmShellVersionMap *self = (ExmShellVersionMap *)object;
+
+    G_OBJECT_CLASS (exm_shell_version_map_parent_class)->finalize (object);
+}
+
+static void
+exm_shell_version_map_get_property (GObject    *object,
+                                    guint       prop_id,
+                                    GValue     *value,
+                                    GParamSpec *pspec)
+{
+    ExmShellVersionMap *self = EXM_SHELL_VERSION_MAP (object);
+
+    switch (prop_id)
+      {
+      default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      }
+}
+
+static void
+exm_shell_version_map_set_property (GObject      *object,
+                                    guint         prop_id,
+                                    const GValue *value,
+                                    GParamSpec   *pspec)
+{
+    ExmShellVersionMap *self = EXM_SHELL_VERSION_MAP (object);
+
+    switch (prop_id)
+      {
+      default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      }
+}
+
+static void
+exm_shell_version_map_class_init (ExmShellVersionMapClass *klass)
+{
+    GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+    object_class->finalize = exm_shell_version_map_finalize;
+    object_class->get_property = exm_shell_version_map_get_property;
+    object_class->set_property = exm_shell_version_map_set_property;
+}
+
+static void
+exm_shell_version_map_init (ExmShellVersionMap *self)
+{
+}

--- a/src/web/model/exm-shell-version-map.h
+++ b/src/web/model/exm-shell-version-map.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define EXM_TYPE_SHELL_VERSION_MAP (exm_shell_version_map_get_type())
+
+G_DECLARE_FINAL_TYPE (ExmShellVersionMap, exm_shell_version_map, EXM, SHELL_VERSION_MAP, GObject)
+
+ExmShellVersionMap *exm_shell_version_map_new (void);
+
+G_END_DECLS


### PR DESCRIPTION
Hide debug output by default. This will help actual errors be more easily distinguished.