### PR TITLE
Only allow the installation of compatible extensions

### DIFF
--- a/src/exm-browse-page.blp
+++ b/src/exm-browse-page.blp
@@ -62,15 +62,6 @@ template ExmBrowsePage : Gtk.Widget {
 								halign: center;
 							};
 						}
-
-						Gtk.StackPage {
-							name: "page_empty";
-							child: Gtk.Label {
-								label: _("No Results Found");
-								valign: start;
-								halign: center;
-							};
-						}
 					}
 				}
 			};

--- a/src/exm-browse-page.c
+++ b/src/exm-browse-page.c
@@ -101,10 +101,7 @@ search_widget_factory (ExmSearchResult *result,
     is_installed = exm_manager_is_installed_uuid (self->manager, uuid);
     is_supported = exm_search_result_supports_shell_version (result, self->shell_version);
 
-    // if (!is_supported)
-    //    return NULL;
-
-    row = exm_search_row_new (result, is_installed);
+    row = exm_search_row_new (result, is_installed, is_supported);
 
     return GTK_WIDGET (row);
 }

--- a/src/exm-browse-page.c
+++ b/src/exm-browse-page.c
@@ -18,6 +18,7 @@ struct _ExmBrowsePage
     ExmManager *manager;
 
     GListModel *search_results_model;
+    gchar *shell_version;
 
     // Template Widgets
     GtkSearchEntry      *search_entry;
@@ -84,6 +85,13 @@ exm_browse_page_set_property (GObject      *object,
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
+}
+
+static gboolean
+is_extension_compatible (ExmSearchResult *result,
+                         gchar           *shell_version)
+{
+
 }
 
 static GtkWidget *
@@ -185,6 +193,11 @@ on_bind_manager (ExmBrowsePage *self)
                               "items-changed",
                               G_CALLBACK (refresh_search),
                               self);
+
+    g_object_get (self->manager,
+                  "shell-version",
+                  &self->shell_version,
+                  NULL);
 
     refresh_search (self);
 }

--- a/src/exm-browse-page.c
+++ b/src/exm-browse-page.c
@@ -87,13 +87,6 @@ exm_browse_page_set_property (GObject      *object,
     }
 }
 
-static gboolean
-is_extension_compatible (ExmSearchResult *result,
-                         gchar           *shell_version)
-{
-
-}
-
 static GtkWidget *
 search_widget_factory (ExmSearchResult *result,
                        ExmBrowsePage   *self)
@@ -101,10 +94,15 @@ search_widget_factory (ExmSearchResult *result,
     ExmSearchRow *row;
     gchar *uuid;
     gboolean is_installed;
+    gboolean is_supported;
 
     g_object_get (result, "uuid", &uuid, NULL);
 
     is_installed = exm_manager_is_installed_uuid (self->manager, uuid);
+    is_supported = exm_search_result_supports_shell_version (result, self->shell_version);
+
+    // if (!is_supported)
+    //    return NULL;
 
     row = exm_search_row_new (result, is_installed);
 

--- a/src/exm-detail-view.blp
+++ b/src/exm-detail-view.blp
@@ -104,7 +104,10 @@ template ExmDetailView : Gtk.Box {
 								xalign: 0;
 							}
 
-							// TODO: Column View (table?) showing version map
+							Gtk.FlowBox supported_versions {
+								max-children-per-line: 100;
+								selection-mode: none;
+							}
 						}
 					}
 				}

--- a/src/exm-search-row.c
+++ b/src/exm-search-row.c
@@ -104,49 +104,6 @@ exm_search_row_set_property (GObject      *object,
     }
 }
 
-/*static void
-on_image_loaded (GObject      *source,
-                 GAsyncResult *res,
-                 GtkImage     *target)
-{
-    GError *error = NULL;
-    GdkTexture *texture = exm_image_resolver_resolve_finish (EXM_IMAGE_RESOLVER (source),
-                                                             res, &error);
-    if (error)
-    {
-        // TODO: Properly log this
-        g_critical ("%s\n", error->message);
-        return;
-    }
-
-    gtk_image_set_from_paintable (target, GDK_PAINTABLE (texture));
-}
-
-static GtkWidget *
-create_thumbnail (ExmImageResolver *resolver,
-                  const gchar      *icon_uri)
-{
-    GtkWidget *icon;
-
-    icon = gtk_image_new ();
-    gtk_widget_set_valign (icon, GTK_ALIGN_CENTER);
-    gtk_widget_set_halign (icon, GTK_ALIGN_CENTER);
-
-    // Set to default icon
-    gtk_image_set_from_resource (GTK_IMAGE (icon), "/com/mattjakeman/ExtensionManager/icons/plugin.png");
-
-    // If not the default icon, lookup and lazily replace
-    // TODO: There are some outstanding threading issues so avoid downloading for now
-    if (strcmp (icon_uri, "/static/images/plugin.png") != 0)
-    {
-        exm_image_resolver_resolve_async (resolver, icon_uri, NULL,
-                                          (GAsyncReadyCallback) on_image_loaded,
-                                          icon);
-    }
-
-    return icon;
-}*/
-
 static void
 install_remote (GtkButton   *button,
                 const gchar *uuid)
@@ -187,14 +144,6 @@ exm_search_row_constructed (GObject *object)
     gtk_actionable_set_action_name (GTK_ACTIONABLE (self), "win.show-detail");
     gtk_actionable_set_action_target (GTK_ACTIONABLE (self), "(sn)", uuid, pk);
 
-    // icon = create_thumbnail (self->resolver, icon_uri);
-    // adw_expander_row_add_prefix (ADW_EXPANDER_ROW (row), icon);
-
-    // TODO: This should be on-demand otherwise we're downloading far too often
-    // screenshot = gtk_image_new ();
-    // exm_image_resolver_resolve_async (self->resolver, screenshot_uri, NULL, (GAsyncReadyCallback)on_image_loaded, screenshot);
-    // gtk_box_append (GTK_BOX (box), screenshot);
-
     gtk_label_set_label (self->title, name);
     gtk_label_set_label (self->subtitle, creator);
     gtk_label_set_label (self->description_label, description);
@@ -207,13 +156,9 @@ exm_search_row_constructed (GObject *object)
 
     if (!self->is_supported)
     {
-        const gchar *tooltip;
-
-        tooltip = _("This extension is incompatible with your current version of GNOME.");
-
-        gtk_button_set_label (self->install_btn, _("Incompatible"));
+        gtk_button_set_label (self->install_btn, _("Unsupported"));
         gtk_widget_set_sensitive (GTK_WIDGET (self->install_btn), FALSE);
-        gtk_widget_set_tooltip_text (GTK_WIDGET (self->install_btn), tooltip);
+        gtk_widget_add_css_class (GTK_WIDGET (self->install_btn), "warning");
     }
 
     g_signal_connect (self->install_btn, "clicked", G_CALLBACK (install_remote), uuid);

--- a/src/exm-search-row.c
+++ b/src/exm-search-row.c
@@ -8,6 +8,7 @@ struct _ExmSearchRow
 
     ExmSearchResult *search_result;
     gboolean is_installed;
+    gboolean is_supported;
     gchar *uuid;
 
     GtkLabel *description_label;
@@ -22,6 +23,7 @@ enum {
     PROP_0,
     PROP_SEARCH_RESULT,
     PROP_IS_INSTALLED,
+    PROP_IS_SUPPORTED,
     N_PROPS
 };
 
@@ -29,11 +31,13 @@ static GParamSpec *properties [N_PROPS];
 
 ExmSearchRow *
 exm_search_row_new (ExmSearchResult *search_result,
-                    gboolean         is_installed)
+                    gboolean         is_installed,
+                    gboolean         is_supported)
 {
     return g_object_new (EXM_TYPE_SEARCH_ROW,
                          "search-result", search_result,
                          "is-installed", is_installed,
+                         "is-supported", is_supported,
                          NULL);
 }
 
@@ -60,6 +64,9 @@ exm_search_row_get_property (GObject    *object,
         break;
     case PROP_IS_INSTALLED:
         g_value_set_boolean (value, self->is_installed);
+        break;
+    case PROP_IS_SUPPORTED:
+        g_value_set_boolean (value, self->is_supported);
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -88,6 +95,9 @@ exm_search_row_set_property (GObject      *object,
         break;
     case PROP_IS_INSTALLED:
         self->is_installed = g_value_get_boolean (value);
+        break;
+    case PROP_IS_SUPPORTED:
+        self->is_supported = g_value_get_boolean (value);
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -195,6 +205,17 @@ exm_search_row_constructed (GObject *object)
         gtk_widget_set_sensitive (GTK_WIDGET (self->install_btn), FALSE);
     }
 
+    if (!self->is_supported)
+    {
+        const gchar *tooltip;
+
+        tooltip = _("This extension is incompatible with your current GNOME Shell version.");
+
+        gtk_button_set_label (self->install_btn, _("Incompatible"));
+        gtk_widget_set_sensitive (GTK_WIDGET (self->install_btn), FALSE);
+        gtk_widget_set_tooltip_text (GTK_WIDGET (self->install_btn), tooltip);
+    }
+
     g_signal_connect (self->install_btn, "clicked", G_CALLBACK (install_remote), uuid);
 }
 
@@ -219,6 +240,13 @@ exm_search_row_class_init (ExmSearchRowClass *klass)
         g_param_spec_boolean ("is-installed",
                               "Is Installed",
                               "Is Installed",
+                              FALSE,
+                              G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY);
+
+    properties [PROP_IS_SUPPORTED] =
+        g_param_spec_boolean ("is-supported",
+                              "Is Supported",
+                              "Is Supported",
                               FALSE,
                               G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY);
 

--- a/src/exm-search-row.c
+++ b/src/exm-search-row.c
@@ -209,7 +209,7 @@ exm_search_row_constructed (GObject *object)
     {
         const gchar *tooltip;
 
-        tooltip = _("This extension is incompatible with your current GNOME Shell version.");
+        tooltip = _("This extension is incompatible with your current version of GNOME.");
 
         gtk_button_set_label (self->install_btn, _("Incompatible"));
         gtk_widget_set_sensitive (GTK_WIDGET (self->install_btn), FALSE);

--- a/src/exm-search-row.h
+++ b/src/exm-search-row.h
@@ -11,6 +11,7 @@ G_BEGIN_DECLS
 G_DECLARE_FINAL_TYPE (ExmSearchRow, exm_search_row, EXM, SEARCH_ROW, GtkListBoxRow)
 
 ExmSearchRow *exm_search_row_new (ExmSearchResult *search_result,
-                                  gboolean         is_installed);
+                                  gboolean         is_installed,
+                                  gboolean         is_supported);
 
 G_END_DECLS

--- a/src/exm-window.c
+++ b/src/exm-window.c
@@ -291,6 +291,12 @@ exm_window_init (ExmWindow *self)
     g_object_set (self->detail_view, "manager", self->manager, NULL);
 
     g_object_bind_property (self->manager,
+                            "shell-version",
+                            self->detail_view,
+                            "shell-version",
+                            G_BINDING_SYNC_CREATE);
+
+    g_object_bind_property (self->manager,
                             "extensions-enabled",
                             self->global_toggle,
                             "state",

--- a/src/style.css
+++ b/src/style.css
@@ -9,3 +9,11 @@
 .search-row {
   padding: 10px 5px;
 }
+
+.version-label {
+    background-color: #62a0ea;
+    color: white;
+    border-radius: 4px;
+    padding: 4px;
+    box-shadow: 0 0 2px rgba(0,0,0,0.2);
+}

--- a/src/web/meson.build
+++ b/src/web/meson.build
@@ -4,5 +4,6 @@ exm_sources += files([
   'exm-request-handler.c',
   'exm-data-provider.c',
   'model/exm-search-result.c',
-  'model/exm-comment.c'
+  'model/exm-comment.c',
+  'model/exm-shell-version-map.c'
 ])

--- a/src/web/model/exm-search-result.c
+++ b/src/web/model/exm-search-result.c
@@ -52,6 +52,8 @@ exm_search_result_finalize (GObject *object)
 {
     ExmSearchResult *self = (ExmSearchResult *)object;
 
+    g_clear_pointer (&self->shell_version_map, exm_shell_version_map_unref);
+
     G_OBJECT_CLASS (exm_search_result_parent_class)->finalize (object);
 }
 
@@ -105,6 +107,8 @@ exm_search_result_set_property (GObject      *object,
 {
     ExmSearchResult *self = EXM_SEARCH_RESULT (object);
 
+    const ExmShellVersionMap *map;
+
     switch (prop_id)
     {
     case PROP_UUID:
@@ -132,11 +136,24 @@ exm_search_result_set_property (GObject      *object,
         self->pk = g_value_get_int (value);
         break;
     case PROP_SHELL_VERSION_MAP:
-        self->shell_version_map = g_value_get_boxed (value);
+        if (self->shell_version_map)
+            exm_shell_version_map_unref (self->shell_version_map);
+
+        self->shell_version_map = exm_shell_version_map_ref (g_value_get_boxed (value));
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
+}
+
+gboolean
+exm_search_result_supports_shell_version (ExmSearchResult *self,
+                                          const gchar     *shell_version)
+{
+    g_return_val_if_fail (shell_version, FALSE);
+
+    return exm_shell_version_map_supports (self->shell_version_map,
+                                           shell_version);
 }
 
 static void

--- a/src/web/model/exm-search-result.c
+++ b/src/web/model/exm-search-result.c
@@ -137,7 +137,7 @@ exm_search_result_set_property (GObject      *object,
         break;
     case PROP_SHELL_VERSION_MAP:
         if (self->shell_version_map)
-            exm_shell_version_map_unref (self->shell_version_map);
+            g_clear_pointer (&self->shell_version_map, exm_shell_version_map_unref);
 
         self->shell_version_map = exm_shell_version_map_ref (g_value_get_boxed (value));
         break;

--- a/src/web/model/exm-search-result.c
+++ b/src/web/model/exm-search-result.c
@@ -1,5 +1,7 @@
 #include "exm-search-result.h"
 
+#include "exm-shell-version-map.h"
+
 #include <json-glib/json-glib.h>
 
 struct _ExmSearchResult
@@ -14,6 +16,7 @@ struct _ExmSearchResult
     gchar *link;
     gchar *description;
     int pk;
+    ExmShellVersionMap *shell_version_map;
 };
 
 static void json_serializable_iface_init (JsonSerializableIface *iface);
@@ -32,6 +35,7 @@ enum {
     PROP_LINK,
     PROP_DESCRIPTION,
     PROP_PK,
+    PROP_SHELL_VERSION_MAP,
     N_PROPS
 };
 
@@ -85,6 +89,9 @@ exm_search_result_get_property (GObject    *object,
     case PROP_PK:
         g_value_set_int (value, self->pk);
         break;
+    case PROP_SHELL_VERSION_MAP:
+        g_value_set_boxed (value, self->shell_version_map);
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
@@ -124,9 +131,46 @@ exm_search_result_set_property (GObject      *object,
     case PROP_PK:
         self->pk = g_value_get_int (value);
         break;
+    case PROP_SHELL_VERSION_MAP:
+        self->shell_version_map = g_value_get_boxed (value);
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
+}
+
+static void
+deserialize_version (JsonObject         *object,
+                     const gchar        *shell_version,
+                     JsonNode           *member_node,
+                     ExmShellVersionMap *version_map)
+{
+    int package;
+    double version;
+    JsonObject *version_obj;
+
+    version_obj = json_node_get_object (member_node);
+
+    package = json_object_get_int_member (version_obj, "pk");
+    version = json_object_get_double_member (version_obj, "version");
+
+    exm_shell_version_map_add (version_map, shell_version, package, version);
+}
+
+static gpointer
+deserialize_shell_version_map (JsonNode* node)
+{
+    ExmShellVersionMap *version_map;
+    JsonObject *object;
+
+    version_map = exm_shell_version_map_new ();
+
+    g_assert (JSON_NODE_HOLDS_OBJECT (node));
+    object = json_node_get_object (node);
+
+    json_object_foreach_member (object, (JsonObjectForeach) deserialize_version, version_map);
+
+    return version_map;
 }
 
 static void
@@ -194,7 +238,18 @@ exm_search_result_class_init (ExmSearchResultClass *klass)
                           0, G_MAXINT, 0,
                           G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY);
 
+    properties [PROP_SHELL_VERSION_MAP] =
+        g_param_spec_boxed ("shell_version_map",
+                             "Shell Version Map",
+                             "Shell Version Map",
+                             EXM_TYPE_SHELL_VERSION_MAP,
+                             G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY);
+
     g_object_class_install_properties (object_class, N_PROPS, properties);
+
+    json_boxed_register_deserialize_func (EXM_TYPE_SHELL_VERSION_MAP,
+                                          JSON_NODE_OBJECT,
+                                          deserialize_shell_version_map);
 }
 
 static void
@@ -205,5 +260,4 @@ exm_search_result_init (ExmSearchResult *self)
 static void
 json_serializable_iface_init (JsonSerializableIface *iface)
 {
-
 }

--- a/src/web/model/exm-search-result.h
+++ b/src/web/model/exm-search-result.h
@@ -10,4 +10,7 @@ G_DECLARE_FINAL_TYPE (ExmSearchResult, exm_search_result, EXM, SEARCH_RESULT, GO
 
 ExmSearchResult *exm_search_result_new (void);
 
+gboolean exm_search_result_supports_shell_version (ExmSearchResult *self,
+                                                   const gchar     *shell_version);
+
 G_END_DECLS

--- a/src/web/model/exm-shell-version-map.c
+++ b/src/web/model/exm-shell-version-map.c
@@ -1,13 +1,5 @@
 #include "exm-shell-version-map.h"
 
-typedef struct
-{
-    gchar *shell_major_version;
-    gchar *shell_minor_version;
-    int extension_package;
-    double extension_version;
-} MapEntry;
-
 G_DEFINE_BOXED_TYPE (ExmShellVersionMap, exm_shell_version_map, exm_shell_version_map_ref, exm_shell_version_map_unref)
 
 /**

--- a/src/web/model/exm-shell-version-map.c
+++ b/src/web/model/exm-shell-version-map.c
@@ -2,16 +2,13 @@
 
 typedef struct
 {
-    int package;
-    double version;
-} VersionTuple;
+    gchar *shell_major_version;
+    gchar *shell_minor_version;
+    int extension_package;
+    double extension_version;
+} MapEntry;
 
-G_DEFINE_BOXED_TYPE (ExmShellVersionMap, exm_shell_version_map, exm_shell_version_map_copy, exm_shell_version_map_free)
-
-struct _ExmShellVersionMap
-{
-    GHashTable *table;
-};
+G_DEFINE_BOXED_TYPE (ExmShellVersionMap, exm_shell_version_map, exm_shell_version_map_ref, exm_shell_version_map_unref)
 
 /**
  * exm_shell_version_map_new:
@@ -26,46 +23,67 @@ exm_shell_version_map_new (void)
     ExmShellVersionMap *self;
 
     self = g_slice_new0 (ExmShellVersionMap);
+    self->ref_count = 1;
 
-    self->table = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+    return self;
+}
+
+static void
+free_entry (MapEntry *entry)
+{
+    g_free (entry->shell_major_version);
+
+    if (entry->shell_minor_version)
+        g_free (entry->shell_minor_version);
+
+    g_slice_free (MapEntry, entry);
+}
+
+static void
+exm_shell_version_map_free (ExmShellVersionMap *self)
+{
+    g_assert (self);
+    g_assert_cmpint (self->ref_count, ==, 0);
+
+    g_list_free_full (g_steal_pointer (&self->map), (GDestroyNotify) free_entry);
+
+    g_slice_free (ExmShellVersionMap, self);
+}
+
+/**
+ * exm_shell_version_map_ref:
+ * @self: A #ExmShellVersionMap
+ *
+ * Increments the reference count of @self by one.
+ *
+ * Returns: (transfer full): @self
+ */
+ExmShellVersionMap *
+exm_shell_version_map_ref (ExmShellVersionMap *self)
+{
+    g_return_val_if_fail (self, NULL);
+    g_return_val_if_fail (self->ref_count, NULL);
+
+    g_atomic_int_inc (&self->ref_count);
 
     return self;
 }
 
 /**
- * exm_shell_version_map_copy:
- * @self: a #ExmShellVersionMap
+ * exm_shell_version_map_unref:
+ * @self: A #ExmShellVersionMap
  *
- * Makes a deep copy of a #ExmShellVersionMap.
- *
- * Returns: (transfer full): A newly created #ExmShellVersionMap with the same
- *   contents as @self
- */
-ExmShellVersionMap *
-exm_shell_version_map_copy (ExmShellVersionMap *self)
-{
-    ExmShellVersionMap *copy;
-
-    g_return_val_if_fail (self, NULL);
-
-    copy = exm_shell_version_map_new ();
-
-    return copy;
-}
-
-/**
- * exm_shell_version_map_free:
- * @self: a #ExmShellVersionMap
- *
- * Frees a #ExmShellVersionMap allocated using exm_shell_version_map_new()
- * or exm_shell_version_map_copy().
+ * Decrements the reference count of @self by one, freeing the structure when
+ * the reference count reaches zero.
  */
 void
-exm_shell_version_map_free (ExmShellVersionMap *self)
+exm_shell_version_map_unref (ExmShellVersionMap *self)
 {
     g_return_if_fail (self);
+    g_return_if_fail (self->ref_count);
 
-    g_slice_free (ExmShellVersionMap, self);
+    if (g_atomic_int_dec_and_test (&self->ref_count))
+        exm_shell_version_map_free (self);
 }
 
 void
@@ -74,9 +92,59 @@ exm_shell_version_map_add (ExmShellVersionMap *self,
                            int                 ext_package,
                            double              ext_version)
 {
-    VersionTuple *tuple = g_new0 (VersionTuple, 1);
-    tuple->package = ext_package;
-    tuple->version = ext_version;
+    gchar **strarr;
+    const gchar *major;
+    const gchar *minor;
 
-    g_hash_table_insert (self->table, g_strdup (shell_version), tuple);
+    strarr = g_strsplit (shell_version, ".", 2);
+
+    major = strarr[0];
+    minor = strarr[1];
+
+    g_debug ("Parsed Version: %s as %s.%s\n", shell_version, major, minor);
+
+    MapEntry *entry = g_slice_new0 (MapEntry);
+    entry->shell_major_version = g_strdup (major);
+    entry->shell_minor_version = g_strdup (minor);
+    entry->extension_version = ext_version;
+    entry->extension_package = ext_package;
+
+    self->map = g_list_append (self->map, entry);
+}
+
+gboolean
+exm_shell_version_map_supports (ExmShellVersionMap *self,
+                                const gchar        *shell_version)
+{
+    // The shell_version string can be either in the form 3.32, 3.36,
+    // 3.38, etc or it can be 40, 41, etc. As a rule, we return true
+    // if the provided `shell_version` is equal or more specific to
+    // the version string stored in the version map.
+
+    gchar **strarr;
+    GList *element;
+    const gchar *major;
+    const gchar *minor;
+
+    g_return_val_if_fail (self->map, FALSE);
+
+    strarr = g_strsplit (shell_version, ".", 2);
+
+    major = strarr[0];
+    minor = strarr[1];
+
+    for (element = self->map;
+         element != NULL;
+         element = element->next)
+    {
+        MapEntry *entry = element->data;
+        if (!g_str_equal (major, entry->shell_major_version))
+            continue;
+
+        if (!entry->shell_minor_version ||
+            g_str_equal (entry->shell_minor_version, minor))
+            return TRUE;
+    }
+
+    return FALSE;
 }

--- a/src/web/model/exm-shell-version-map.c
+++ b/src/web/model/exm-shell-version-map.c
@@ -1,74 +1,82 @@
 #include "exm-shell-version-map.h"
 
+typedef struct
+{
+    int package;
+    double version;
+} VersionTuple;
+
+G_DEFINE_BOXED_TYPE (ExmShellVersionMap, exm_shell_version_map, exm_shell_version_map_copy, exm_shell_version_map_free)
+
 struct _ExmShellVersionMap
 {
-    GObject parent_instance;
+    GHashTable *table;
 };
 
-G_DEFINE_FINAL_TYPE (ExmShellVersionMap, exm_shell_version_map, G_TYPE_OBJECT)
-
-enum {
-    PROP_0,
-    N_PROPS
-};
-
-static GParamSpec *properties [N_PROPS];
-
+/**
+ * exm_shell_version_map_new:
+ *
+ * Creates a new #ExmShellVersionMap.
+ *
+ * Returns: (transfer full): A newly created #ExmShellVersionMap
+ */
 ExmShellVersionMap *
 exm_shell_version_map_new (void)
 {
-    return g_object_new (EXM_TYPE_SHELL_VERSION_MAP, NULL);
+    ExmShellVersionMap *self;
+
+    self = g_slice_new0 (ExmShellVersionMap);
+
+    self->table = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+
+    return self;
 }
 
-static void
-exm_shell_version_map_finalize (GObject *object)
+/**
+ * exm_shell_version_map_copy:
+ * @self: a #ExmShellVersionMap
+ *
+ * Makes a deep copy of a #ExmShellVersionMap.
+ *
+ * Returns: (transfer full): A newly created #ExmShellVersionMap with the same
+ *   contents as @self
+ */
+ExmShellVersionMap *
+exm_shell_version_map_copy (ExmShellVersionMap *self)
 {
-    ExmShellVersionMap *self = (ExmShellVersionMap *)object;
+    ExmShellVersionMap *copy;
 
-    G_OBJECT_CLASS (exm_shell_version_map_parent_class)->finalize (object);
+    g_return_val_if_fail (self, NULL);
+
+    copy = exm_shell_version_map_new ();
+
+    return copy;
 }
 
-static void
-exm_shell_version_map_get_property (GObject    *object,
-                                    guint       prop_id,
-                                    GValue     *value,
-                                    GParamSpec *pspec)
+/**
+ * exm_shell_version_map_free:
+ * @self: a #ExmShellVersionMap
+ *
+ * Frees a #ExmShellVersionMap allocated using exm_shell_version_map_new()
+ * or exm_shell_version_map_copy().
+ */
+void
+exm_shell_version_map_free (ExmShellVersionMap *self)
 {
-    ExmShellVersionMap *self = EXM_SHELL_VERSION_MAP (object);
+    g_return_if_fail (self);
 
-    switch (prop_id)
-      {
-      default:
-        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-      }
+    g_slice_free (ExmShellVersionMap, self);
 }
 
-static void
-exm_shell_version_map_set_property (GObject      *object,
-                                    guint         prop_id,
-                                    const GValue *value,
-                                    GParamSpec   *pspec)
+void
+exm_shell_version_map_add (ExmShellVersionMap *self,
+                           const gchar        *shell_version,
+                           int                 ext_package,
+                           double              ext_version)
 {
-    ExmShellVersionMap *self = EXM_SHELL_VERSION_MAP (object);
+    VersionTuple *tuple = g_new0 (VersionTuple, 1);
+    tuple->package = ext_package;
+    tuple->version = ext_version;
 
-    switch (prop_id)
-      {
-      default:
-        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-      }
-}
-
-static void
-exm_shell_version_map_class_init (ExmShellVersionMapClass *klass)
-{
-    GObjectClass *object_class = G_OBJECT_CLASS (klass);
-
-    object_class->finalize = exm_shell_version_map_finalize;
-    object_class->get_property = exm_shell_version_map_get_property;
-    object_class->set_property = exm_shell_version_map_set_property;
-}
-
-static void
-exm_shell_version_map_init (ExmShellVersionMap *self)
-{
+    g_hash_table_insert (self->table, g_strdup (shell_version), tuple);
 }

--- a/src/web/model/exm-shell-version-map.c
+++ b/src/web/model/exm-shell-version-map.c
@@ -126,7 +126,10 @@ exm_shell_version_map_supports (ExmShellVersionMap *self,
     const gchar *major;
     const gchar *minor;
 
-    g_return_val_if_fail (self->map, FALSE);
+    // Some entries on the website do not define a shell_version_map. Assume
+    // these extensions have been retired and ignore.
+    if (self->map == NULL)
+        return FALSE;
 
     strarr = g_strsplit (shell_version, ".", 2);
 

--- a/src/web/model/exm-shell-version-map.h
+++ b/src/web/model/exm-shell-version-map.h
@@ -4,10 +4,19 @@
 
 G_BEGIN_DECLS
 
-#define EXM_TYPE_SHELL_VERSION_MAP (exm_shell_version_map_get_type())
+#define EXM_TYPE_SHELL_VERSION_MAP (exm_shell_version_map_get_type ())
 
-G_DECLARE_FINAL_TYPE (ExmShellVersionMap, exm_shell_version_map, EXM, SHELL_VERSION_MAP, GObject)
+typedef struct _ExmShellVersionMap ExmShellVersionMap;
 
-ExmShellVersionMap *exm_shell_version_map_new (void);
+GType                   exm_shell_version_map_get_type (void) G_GNUC_CONST;
+ExmShellVersionMap     *exm_shell_version_map_new      (void);
+ExmShellVersionMap     *exm_shell_version_map_copy     (ExmShellVersionMap *self);
+void                    exm_shell_version_map_free     (ExmShellVersionMap *self);
+void                    exm_shell_version_map_add      (ExmShellVersionMap *self,
+                                                        const gchar        *shell_version,
+                                                        int                 ext_package,
+                                                        double              ext_version);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (ExmShellVersionMap, exm_shell_version_map_free)
 
 G_END_DECLS

--- a/src/web/model/exm-shell-version-map.h
+++ b/src/web/model/exm-shell-version-map.h
@@ -8,15 +8,25 @@ G_BEGIN_DECLS
 
 typedef struct _ExmShellVersionMap ExmShellVersionMap;
 
+struct _ExmShellVersionMap
+{
+    /*< private >*/
+    guint ref_count;
+    GList *map;
+
+};
+
 GType                   exm_shell_version_map_get_type (void) G_GNUC_CONST;
 ExmShellVersionMap     *exm_shell_version_map_new      (void);
-ExmShellVersionMap     *exm_shell_version_map_copy     (ExmShellVersionMap *self);
-void                    exm_shell_version_map_free     (ExmShellVersionMap *self);
+ExmShellVersionMap     *exm_shell_version_map_ref      (ExmShellVersionMap *self);
+void                    exm_shell_version_map_unref    (ExmShellVersionMap *self);
 void                    exm_shell_version_map_add      (ExmShellVersionMap *self,
                                                         const gchar        *shell_version,
                                                         int                 ext_package,
                                                         double              ext_version);
+gboolean                exm_shell_version_map_supports (ExmShellVersionMap *self,
+                                                        const gchar        *shell_version);
 
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (ExmShellVersionMap, exm_shell_version_map_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (ExmShellVersionMap, exm_shell_version_map_unref)
 
 G_END_DECLS

--- a/src/web/model/exm-shell-version-map.h
+++ b/src/web/model/exm-shell-version-map.h
@@ -8,6 +8,14 @@ G_BEGIN_DECLS
 
 typedef struct _ExmShellVersionMap ExmShellVersionMap;
 
+typedef struct
+{
+    gchar *shell_major_version;
+    gchar *shell_minor_version;
+    int extension_package;
+    double extension_version;
+} MapEntry;
+
 struct _ExmShellVersionMap
 {
     /*< private >*/


### PR DESCRIPTION
Parse the shell_version_map json object and use this to determine whether the extension is installable.

If not supported, display the following message and tooltip:

![image](https://user-images.githubusercontent.com/12368711/150331567-86c71fb3-a247-499d-9a46-559c1b041c18.png)

TODO:
 - [ ] Check that this still functions on GNOME Versions 3.38 and under
 - [X] Rebase on #51 

Fixes #5 