### PR TITLE
i18n: Add context to various translation strings

### DIFF
--- a/src/exm-detail-view.c
+++ b/src/exm-detail-view.c
@@ -131,7 +131,7 @@ install_btn_set_state (GtkButton          *button,
         gtk_widget_add_css_class (GTK_WIDGET (button), "suggested-action");
         break;
     case STATE_INSTALLED:
-        gtk_button_set_label (button, _("Installed"));
+        gtk_button_set_label (button, C_("State", "Installed"));
         gtk_widget_set_sensitive (GTK_WIDGET (button), FALSE);
         break;
     case STATE_UNSUPPORTED:

--- a/src/exm-search-row.c
+++ b/src/exm-search-row.c
@@ -149,7 +149,7 @@ exm_search_row_constructed (GObject *object)
 
     if (self->is_installed)
     {
-        gtk_button_set_label (self->install_btn, _("Installed"));
+        gtk_button_set_label (self->install_btn, C_("State", "Installed"));
         gtk_widget_set_sensitive (GTK_WIDGET (self->install_btn), FALSE);
     }
 

--- a/src/exm-window.blp
+++ b/src/exm-window.blp
@@ -39,7 +39,7 @@ template ExmWindow : Adw.ApplicationWindow {
 
 					 Adw.ViewStackPage {
 						name: "installed";
-						title: _("Installed");
+						title: C_("Navigation", "Installed");
 						icon-name: "puzzle-piece-symbolic";
 
 						child: .ExmInstalledPage installed_page {};
@@ -47,7 +47,7 @@ template ExmWindow : Adw.ApplicationWindow {
 
 					Adw.ViewStackPage {
 						name: "browse";
-						title: _("Browse");
+						title: C_("Navigation", "Browse");
 						icon-name: "globe-symbolic";
 
 						child: .ExmBrowsePage browse_page {};


### PR DESCRIPTION
This is necessary as some languages have different words for e.g. "Installed [Extensions]" (plural) and "[It is] Installed" (singular). New contextual strings for other instances of this can be added as and when needed.

Fixes #112 