### PR TITLE
project: Don't require internet access for appstream validate test

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -44,7 +44,7 @@ appstream_file = i18n.merge_file(
 appstream_util = find_program('appstream-util', required: false)
 if appstream_util.found()
   test('Validate appstream file', appstream_util,
-    args: ['validate-relax', appstream_file]
+    args: ['validate-relax', '--nonet', appstream_file]
   )
 endif
 


### PR DESCRIPTION
Official distro build machines often don't have internet access but distros often still like to run all available build tests.