### PR TITLE
Add option to sort extensions by enabled status

### DIFF
--- a/data/com.mattjakeman.ExtensionManager.gschema.xml.in
+++ b/data/com.mattjakeman.ExtensionManager.gschema.xml.in
@@ -16,5 +16,10 @@
       <summary>Last-Used Version</summary>
       <description>The last-used version of the app. If the saved version does not match, the "What's New" dialog is shown.</description>
     </key>
+    <key name="sort-enabled-first" type="b">
+      <default>false</default>
+      <summary>Sort Enabled First</summary>
+      <description>Display enabled extensions first in the installed view.</description>
+    </key>
   </schema>
 </schemalist>

--- a/src/exm-application.c
+++ b/src/exm-application.c
@@ -197,6 +197,9 @@ exm_application_init (ExmApplication *self)
     g_signal_connect_swapped (logout_action, "activate", G_CALLBACK (request_logout), self);
     g_action_map_add_action (G_ACTION_MAP (self), G_ACTION (logout_action));
 
+    GAction *sort_enabled_first_action = g_settings_create_action (settings, "sort-enabled-first");
+    g_action_map_add_action (G_ACTION_MAP (self), G_ACTION (sort_enabled_first_action));
+
     GAction *style_variant_action = g_settings_create_action (settings, "style-variant");
     g_action_map_add_action (G_ACTION_MAP (self), G_ACTION (style_variant_action));
 

--- a/src/exm-extension-row.c
+++ b/src/exm-extension-row.c
@@ -168,7 +168,8 @@ set_error_label_visible (ExmExtensionRow *self,
 }
 
 static void
-exm_extension_row_constructed (GObject *object)
+exm_extension_row_bind_extension (GObject    *object,
+                                  GParamSpec *pspec)
 {
     // TODO: This big block of property assignments is currently copy/pasted
     // from ExmExtension. We can replace this with GtkExpression lookups
@@ -176,6 +177,11 @@ exm_extension_row_constructed (GObject *object)
     // (See https://gitlab.gnome.org/jwestman/blueprint-compiler/-/issues/5)
 
     ExmExtensionRow *self = EXM_EXTENSION_ROW (object);
+
+    g_return_if_fail (pspec == properties [PROP_EXTENSION]);
+
+    if (self->extension == NULL)
+        return;
 
     gchar *name, *uuid, *description, *version, *error_msg;
     gboolean has_prefs, has_update, is_user;
@@ -226,8 +232,6 @@ exm_extension_row_constructed (GObject *object)
     g_simple_action_set_enabled (G_SIMPLE_ACTION (action), is_user);
 
     update_state (self->extension, NULL, self);
-
-    G_OBJECT_CLASS (exm_extension_row_parent_class)->constructed (object);
 }
 
 static void
@@ -238,7 +242,6 @@ exm_extension_row_class_init (ExmExtensionRowClass *klass)
     object_class->finalize = exm_extension_row_finalize;
     object_class->get_property = exm_extension_row_get_property;
     object_class->set_property = exm_extension_row_set_property;
-    object_class->constructed = exm_extension_row_constructed;
 
     properties [PROP_EXTENSION] =
         g_param_spec_object ("extension",
@@ -319,6 +322,11 @@ exm_extension_row_init (ExmExtensionRow *self)
     GSimpleAction *remove_action;
 
     gtk_widget_init_template (GTK_WIDGET (self));
+
+    g_signal_connect (self,
+                      "notify::extension",
+                      G_CALLBACK (exm_extension_row_bind_extension),
+                      NULL);
 
     // Define Actions
     self->action_group = g_simple_action_group_new ();

--- a/src/exm-installed-page.c
+++ b/src/exm-installed-page.c
@@ -165,9 +165,7 @@ bind_list_box (GtkListBox *list_box,
                gboolean    sort_enabled_first)
 {
     GtkExpression *expression;
-    GtkCustomSorter *enabled_sorter;
     GtkStringSorter *alphabetical_sorter;
-    GtkMultiSorter *multi_sorter;
     GtkSortListModel *sorted_model;
 
     // Sort alphabetically
@@ -176,6 +174,9 @@ bind_list_box (GtkListBox *list_box,
 
     if (sort_enabled_first)
     {
+        GtkCustomSorter *enabled_sorter;
+        GtkMultiSorter *multi_sorter;
+
         // Sort by enabled
         enabled_sorter = gtk_custom_sorter_new ((GCompareDataFunc) compare_enabled, NULL, NULL);
 

--- a/src/exm-window.blp
+++ b/src/exm-window.blp
@@ -92,6 +92,10 @@ menu primary_menu {
       action: "win.show-release-notes";
     }
     item {
+      label: _("Sort Enabled First");
+      action: "app.sort-enabled-first";
+    }
+    item {
       label: _("About Extension Manager");
       action: "app.about";
     }

--- a/src/local/exm-manager.c
+++ b/src/local/exm-manager.c
@@ -696,6 +696,13 @@ on_state_changed (ShellExtensions *object,
         return;
     }
 
+    // Emit items-changed signal to re-sort extension list
+    {
+        guint position;
+        if (g_list_store_find_with_equal_func (list_store, extension, (GEqualFunc)is_extension_equal, &position))
+            g_list_model_items_changed (G_LIST_MODEL (list_store), position, 1, 1);
+    }
+
     // If the extension that has changed has an update, then
     // one or more extensions have updates available. Lazily
     // check the exact number and emit the 'updates-available'


### PR DESCRIPTION
 - [x] Add setting to sort extensions by enabled status
 - [x] Display enabled extensions first
 - [x] Fix crash that sometimes occurs
 - [x] Respect setting state
 - [x] Fix sometimes broken behaviour
     - [x] Accessing ExmExtensionRow with the GTK inspector causes the application to crash
     - [x] Fix desync between the list model and the rows as a result of sorting
     - [x] Toggling extensions makes rows slowly become wider??

Fixes #97 