### PR TITLE
metainfo: Update for standard install location, part two

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -38,7 +38,7 @@ appstream_file = i18n.merge_file(
   output: '@0@.appdata.xml'.format(app_id),
   po_dir: '../po',
   install: true,
-  install_dir: join_paths(get_option('datadir'), 'appdata')
+  install_dir: join_paths(get_option('datadir'), 'metainfo')
 )
 
 appstream_util = find_program('appstream-util', required: false)


### PR DESCRIPTION
I missed one detail from fdf8675ad

https://freedesktop.org/software/appstream/docs/sect-Metadata-Application.html