### PR TITLE
plugin: Add extension-manager-utils plugin for GNOME Shell

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,0 +1,8 @@
+# Extension Manager Utils
+A GNOME Shell extension that makes various changes to GNOME Shell needed by
+Extension Manager.
+
+## Why do I need this?
+This extension allows Extension Manager to:
+ - Check for updates without needing the official org.gnome.Extensions app to
+   also be installed.

--- a/plugin/extension.js
+++ b/plugin/extension.js
@@ -1,0 +1,73 @@
+/* extension.js
+ *
+ * Copyright 2022 Matthew Jakeman <mjakeman26@outlook.co.nz>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+'use strict'
+
+const { GLib, Gio, GObject, Shell, St } = imports.gi;
+var oldMethod = null;
+
+function fixUpdateMechanism() {
+    // GNOME Shell currently will only check for updates if the official
+    // org.gnome.Extensions app is installed. We modify this check so
+    // that updating can take place if Extension Manager is the sole
+    // manager app on the system.
+
+    // Get the shell's built-in extension manager object
+    var shellExtensionManager = imports.ui.extensionSystem.ExtensionManager;
+
+    // Save the old method to restore later
+    oldMethod = Object.getOwnPropertyDescriptor(shellExtensionManager.prototype, 'updatesSupported').get.bind({});
+
+    // Add workaround for Extension Manager
+    Object.defineProperty(shellExtensionManager.prototype, 'updatesSupported', {
+        get: function() {
+            const appSys = Shell.AppSystem.get_default();
+            return (appSys.lookup_app('org.gnome.Extensions.desktop') != null) ||
+                   (appSys.lookup_app('com.mattjakeman.ExtensionManager.desktop') != null);
+        }
+    });
+}
+
+function unfixUpdateMechanism() {
+    // Get the shell's built-in extension manager object
+    var shellExtensionManager = imports.ui.extensionSystem.ExtensionManager;
+
+    // Restore old method
+    Object.defineProperty(shellExtensionManager.prototype, 'updatesSupported', {
+        get: oldMethod
+    });
+}
+
+class Extension {
+    constructor() {
+    }
+
+    enable() {
+        fixUpdateMechanism();
+    }
+
+    disable() {
+        unfixUpdateMechanism();
+    }
+}
+
+function init() {
+    return new Extension();
+}

--- a/plugin/metadata.json
+++ b/plugin/metadata.json
@@ -1,0 +1,13 @@
+{
+  "name": "Extension Manager Utils",
+  "description": "Makes various changes to GNOME Shell that are needed by Extension Manager.\nRemoves requirement for the 'GNOME Extensions' app to be installed in order to check for extension updates.",
+  "uuid": "extension-manager-utils@mattjakeman.com",
+  "url": "https://github.com/mjakeman/extension-manager",
+  "version": 1,
+  "shell-version": [
+    "3.38",
+    "40",
+    "41",
+    "42"
+  ]
+}


### PR DESCRIPTION
A GNOME Shell extension which patches out the check for `org.gnome.Extensions`. This appears to fix the issue with updating. Let's merge this with the intention of bundling it with Extension Manager 0.4 (the user will be prompted to install it).

**TODO:**
 - [X] Test on GNOME 42
 - [ ] Test on GNOME 41
 - [ ] Test on GNOME 40
 - [x] Test on GNOME 3.38
 - [ ] Fix Notification Issue

It shouldn't be necessary on GNOME 3.36 and below (these are unsupported anyway).

Fixes #165