### PR TITLE
Filter out unsupported extensions by default

### DIFF
--- a/data/com.mattjakeman.ExtensionManager.gschema.xml.in
+++ b/data/com.mattjakeman.ExtensionManager.gschema.xml.in
@@ -21,5 +21,10 @@
       <summary>Sort Enabled First</summary>
       <description>Display enabled extensions first in the installed view.</description>
     </key>
+    <key name="show-unsupported" type="b">
+      <default>false</default>
+      <summary>Show Unsupported</summary>
+      <description>Show extensions which do not support the current version of GNOME.</description>
+    </key>
   </schema>
 </schemalist>

--- a/src/exm-application.c
+++ b/src/exm-application.c
@@ -202,6 +202,9 @@ exm_application_init (ExmApplication *self)
     GAction *sort_enabled_first_action = g_settings_create_action (settings, "sort-enabled-first");
     g_action_map_add_action (G_ACTION_MAP (self), G_ACTION (sort_enabled_first_action));
 
+    GAction *show_unsupported_action = g_settings_create_action (settings, "show-unsupported");
+    g_action_map_add_action (G_ACTION_MAP (self), G_ACTION (show_unsupported_action));
+
     GAction *style_variant_action = g_settings_create_action (settings, "style-variant");
     g_action_map_add_action (G_ACTION_MAP (self), G_ACTION (style_variant_action));
 

--- a/src/exm-browse-page.c
+++ b/src/exm-browse-page.c
@@ -176,6 +176,7 @@ on_bind_manager (ExmBrowsePage *self)
 {
     GListModel *user_ext_model;
     GListModel *system_ext_model;
+    gchar *shell_version;
 
     g_object_get (self->manager,
                   "user-extensions", &user_ext_model,
@@ -194,8 +195,11 @@ on_bind_manager (ExmBrowsePage *self)
 
     g_object_get (self->manager,
                   "shell-version",
-                  &self->shell_version,
+                  &shell_version,
                   NULL);
+
+    self->shell_version = shell_version;
+    g_object_set (self->search, "shell-version", shell_version, NULL);
 
     refresh_search (self);
 }

--- a/src/exm-browse-page.c
+++ b/src/exm-browse-page.c
@@ -9,6 +9,8 @@
 
 #include "web/model/exm-search-result.h"
 
+#include "exm-config.h"
+
 struct _ExmBrowsePage
 {
     GtkWidget parent_instance;
@@ -232,9 +234,24 @@ exm_browse_page_class_init (ExmBrowsePageClass *klass)
 static void
 exm_browse_page_init (ExmBrowsePage *self)
 {
+    GSettings *settings;
     gtk_widget_init_template (GTK_WIDGET (self));
 
     self->search = exm_search_provider_new ();
+
+    settings = g_settings_new (APP_ID);
+
+    g_settings_bind (settings, "show-unsupported",
+                     self->search, "show-unsupported",
+                     G_SETTINGS_BIND_GET);
+
+    // Rerun search when show unsupported is toggled
+    g_signal_connect_swapped (self->search,
+                              "notify::show-unsupported",
+                              G_CALLBACK (on_search_changed),
+                              self);
+
+    g_object_unref (settings);
 
     g_signal_connect_swapped (self->search_entry,
                               "search-changed",

--- a/src/exm-window.blp
+++ b/src/exm-window.blp
@@ -89,6 +89,10 @@ menu primary_menu {
       label: _("Sort Enabled First");
       action: "app.sort-enabled-first";
     }
+    item {
+      label: _("Show Unsupported");
+      action: "app.show-unsupported";
+    }
   }
   section {
     item {

--- a/src/web/exm-search-provider.c
+++ b/src/web/exm-search-provider.c
@@ -7,6 +7,8 @@
 struct _ExmSearchProvider
 {
     ExmRequestHandler parent_instance;
+    const gchar *shell_version;
+    gboolean show_unsupported;
 };
 
 G_DEFINE_FINAL_TYPE (ExmSearchProvider, exm_search_provider, EXM_TYPE_REQUEST_HANDLER)
@@ -107,7 +109,11 @@ exm_search_provider_query_async (ExmSearchProvider   *self,
     const gchar *sort;
 
     sort = get_sort_string (sort_type);
-    url = g_strdup_printf ("https://extensions.gnome.org/extension-query/?search=%s&sort=%s", query, sort);
+
+    if (self->show_unsupported)
+        url = g_strdup_printf ("https://extensions.gnome.org/extension-query/?search=%s&sort=%s", query, sort);
+    else
+        url = g_strdup_printf ("https://extensions.gnome.org/extension-query/?search=%s&sort=%s&shell_version=%s", query, sort, "42");
 
     exm_request_handler_request_async (EXM_REQUEST_HANDLER (self),
                                        url,
@@ -145,4 +151,5 @@ exm_search_provider_class_init (ExmSearchProviderClass *klass)
 static void
 exm_search_provider_init (ExmSearchProvider *self)
 {
+    self->show_unsupported = FALSE;
 }

--- a/src/web/exm-search-provider.c
+++ b/src/web/exm-search-provider.c
@@ -16,6 +16,7 @@ G_DEFINE_FINAL_TYPE (ExmSearchProvider, exm_search_provider, EXM_TYPE_REQUEST_HA
 enum {
     PROP_0,
     PROP_SHOW_UNSUPPORTED,
+    PROP_SHELL_VERSION,
     N_PROPS
 };
 
@@ -48,6 +49,9 @@ exm_search_provider_get_property (GObject    *object,
     case PROP_SHOW_UNSUPPORTED:
         g_value_set_boolean (value, self->show_unsupported);
         break;
+    case PROP_SHELL_VERSION:
+        g_value_set_string (value, self->shell_version);
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
@@ -65,6 +69,9 @@ exm_search_provider_set_property (GObject      *object,
     {
     case PROP_SHOW_UNSUPPORTED:
         self->show_unsupported = g_value_get_boolean (value);
+        break;
+    case PROP_SHELL_VERSION:
+        self->shell_version = g_value_get_string (value);
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -199,11 +206,19 @@ exm_search_provider_class_init (ExmSearchProviderClass *klass)
                                 "Show Unsupported",
                                 FALSE, G_PARAM_READWRITE);
 
+    properties [PROP_SHELL_VERSION]
+        = g_param_spec_string ("shell-version",
+                               "Shell Version",
+                               "Shell Version",
+                               NULL,
+                               G_PARAM_READWRITE);
+
     g_object_class_install_properties (object_class, N_PROPS, properties);
 }
 
 static void
 exm_search_provider_init (ExmSearchProvider *self)
 {
+    // TODO: Get current GNOME Shell Version
     self->shell_version = "42";
 }

--- a/src/web/exm-search-provider.c
+++ b/src/web/exm-search-provider.c
@@ -13,6 +13,14 @@ struct _ExmSearchProvider
 
 G_DEFINE_FINAL_TYPE (ExmSearchProvider, exm_search_provider, EXM_TYPE_REQUEST_HANDLER)
 
+enum {
+    PROP_0,
+    PROP_SHOW_UNSUPPORTED,
+    N_PROPS
+};
+
+static GParamSpec *properties [N_PROPS];
+
 ExmSearchProvider *
 exm_search_provider_new (void)
 {
@@ -25,6 +33,42 @@ exm_search_provider_finalize (GObject *object)
     ExmSearchProvider *self = (ExmSearchProvider *)object;
 
     G_OBJECT_CLASS (exm_search_provider_parent_class)->finalize (object);
+}
+
+static void
+exm_search_provider_get_property (GObject    *object,
+                                  guint       prop_id,
+                                  GValue     *value,
+                                  GParamSpec *pspec)
+{
+    ExmSearchProvider *self = EXM_SEARCH_PROVIDER (object);
+
+    switch (prop_id)
+    {
+    case PROP_SHOW_UNSUPPORTED:
+        g_value_set_boolean (value, self->show_unsupported);
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+exm_search_provider_set_property (GObject      *object,
+                                  guint         prop_id,
+                                  const GValue *value,
+                                  GParamSpec   *pspec)
+{
+    ExmSearchProvider *self = EXM_SEARCH_PROVIDER (object);
+
+    switch (prop_id)
+    {
+    case PROP_SHOW_UNSUPPORTED:
+        self->show_unsupported = g_value_get_boolean (value);
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
 }
 
 static GListModel *
@@ -113,7 +157,7 @@ exm_search_provider_query_async (ExmSearchProvider   *self,
     if (self->show_unsupported)
         url = g_strdup_printf ("https://extensions.gnome.org/extension-query/?search=%s&sort=%s", query, sort);
     else
-        url = g_strdup_printf ("https://extensions.gnome.org/extension-query/?search=%s&sort=%s&shell_version=%s", query, sort, "42");
+        url = g_strdup_printf ("https://extensions.gnome.org/extension-query/?search=%s&sort=%s&shell_version=%s", query, sort, self->shell_version);
 
     exm_request_handler_request_async (EXM_REQUEST_HANDLER (self),
                                        url,
@@ -142,14 +186,24 @@ exm_search_provider_class_init (ExmSearchProviderClass *klass)
     GObjectClass *object_class = G_OBJECT_CLASS (klass);
 
     object_class->finalize = exm_search_provider_finalize;
+    object_class->get_property = exm_search_provider_get_property;
+    object_class->set_property = exm_search_provider_set_property;
 
     ExmRequestHandlerClass *request_handler_class = EXM_REQUEST_HANDLER_CLASS (klass);
 
     request_handler_class->handle_response = (ResponseHandler) parse_search_results;
+
+    properties [PROP_SHOW_UNSUPPORTED]
+        = g_param_spec_boolean ("show-unsupported",
+                                "Show Unsupported",
+                                "Show Unsupported",
+                                FALSE, G_PARAM_READWRITE);
+
+    g_object_class_install_properties (object_class, N_PROPS, properties);
 }
 
 static void
 exm_search_provider_init (ExmSearchProvider *self)
 {
-    self->show_unsupported = FALSE;
+    self->shell_version = "42";
 }


### PR DESCRIPTION
 - Filter out unsupported extensions according to a new 'show-unsupported' setting
 - This setting is disabled by _Default_ - users are discouraged from using unsupported extensions, but the option is there if they wish.

Look how blue it is :0

Fixes #114 

<img width="810" alt="image" src="https://user-images.githubusercontent.com/12368711/177037304-e528ba69-0d41-4cf7-846f-e28087faa636.png">
