### PR TITLE
fix: move icons to gressource

### DIFF
--- a/data/icons/hicolor/meson.build
+++ b/data/icons/hicolor/meson.build
@@ -1,1 +1,0 @@
-install_subdir('scalable', install_dir: icondir)

--- a/data/icons/meson.build
+++ b/data/icons/meson.build
@@ -11,4 +11,3 @@ install_data(
   rename: '@0@-symbolic.svg'.format(app_id),
 )
 
-subdir('hicolor')

--- a/src/exm-rating.c
+++ b/src/exm-rating.c
@@ -13,93 +13,92 @@ struct _ExmRating
     GtkImage *star_five;
 };
 
-G_DEFINE_FINAL_TYPE(ExmRating, exm_rating, GTK_TYPE_WIDGET)
+G_DEFINE_FINAL_TYPE (ExmRating, exm_rating, GTK_TYPE_WIDGET)
 
-enum
-{
+enum {
     PROP_0,
     PROP_RATING,
     N_PROPS
 };
 
-static GParamSpec *properties[N_PROPS];
+static GParamSpec *properties [N_PROPS];
 
 ExmRating *
-exm_rating_new(void)
+exm_rating_new (void)
 {
-    return g_object_new(EXM_TYPE_RATING, NULL);
+    return g_object_new (EXM_TYPE_RATING, NULL);
 }
 
 static void
-exm_rating_finalize(GObject *object)
+exm_rating_finalize (GObject *object)
 {
     ExmRating *self = (ExmRating *)object;
 
-    G_OBJECT_CLASS(exm_rating_parent_class)->finalize(object);
+    G_OBJECT_CLASS (exm_rating_parent_class)->finalize (object);
 }
 
-void update_rating(ExmRating *self);
+void update_rating (ExmRating *self);
 
 static void
-exm_rating_get_property(GObject *object,
-                        guint prop_id,
-                        GValue *value,
-                        GParamSpec *pspec)
+exm_rating_get_property (GObject    *object,
+                         guint       prop_id,
+                         GValue     *value,
+                         GParamSpec *pspec)
 {
-    ExmRating *self = EXM_RATING(object);
+    ExmRating *self = EXM_RATING (object);
 
     switch (prop_id)
     {
     case PROP_RATING:
-        g_value_set_int(value, self->rating);
+        g_value_set_int (value, self->rating);
         break;
     default:
-        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
 }
 
 static void
-exm_rating_set_property(GObject *object,
-                        guint prop_id,
-                        const GValue *value,
-                        GParamSpec *pspec)
+exm_rating_set_property (GObject      *object,
+                         guint         prop_id,
+                         const GValue *value,
+                         GParamSpec   *pspec)
 {
-    ExmRating *self = EXM_RATING(object);
+    ExmRating *self = EXM_RATING (object);
 
     switch (prop_id)
     {
     case PROP_RATING:
-        self->rating = g_value_get_int(value);
-        update_rating(self);
+        self->rating = g_value_get_int (value);
+        update_rating (self);
         break;
     default:
-        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
 }
 
 #define FILLED_ICON_NAME "star-filled-rounded-symbolic"
 #define EMPTY_ICON_NAME "star-outline-rounded-symbolic"
 
-void update_rating(ExmRating *self)
+void update_rating (ExmRating *self)
 {
-    gtk_image_set_from_icon_name(self->star_one, EMPTY_ICON_NAME);
-    gtk_image_set_from_icon_name(self->star_two, EMPTY_ICON_NAME);
-    gtk_image_set_from_icon_name(self->star_three, EMPTY_ICON_NAME);
-    gtk_image_set_from_icon_name(self->star_four, EMPTY_ICON_NAME);
-    gtk_image_set_from_icon_name(self->star_five, EMPTY_ICON_NAME);
+    gtk_image_set_from_icon_name (self->star_one, EMPTY_ICON_NAME);
+    gtk_image_set_from_icon_name (self->star_two, EMPTY_ICON_NAME);
+    gtk_image_set_from_icon_name (self->star_three, EMPTY_ICON_NAME);
+    gtk_image_set_from_icon_name (self->star_four, EMPTY_ICON_NAME);
+    gtk_image_set_from_icon_name (self->star_five, EMPTY_ICON_NAME);
 
     switch (self->rating)
     {
     case 5:
-        gtk_image_set_from_icon_name(self->star_five, FILLED_ICON_NAME);
+        gtk_image_set_from_icon_name (self->star_five, FILLED_ICON_NAME);
     case 4:
-        gtk_image_set_from_icon_name(self->star_four, FILLED_ICON_NAME);
+        gtk_image_set_from_icon_name (self->star_four, FILLED_ICON_NAME);
     case 3:
-        gtk_image_set_from_icon_name(self->star_three, FILLED_ICON_NAME);
+        gtk_image_set_from_icon_name (self->star_three, FILLED_ICON_NAME);
     case 2:
-        gtk_image_set_from_icon_name(self->star_two, FILLED_ICON_NAME);
+        gtk_image_set_from_icon_name (self->star_two, FILLED_ICON_NAME);
     case 1:
-        gtk_image_set_from_icon_name(self->star_one, FILLED_ICON_NAME);
+        gtk_image_set_from_icon_name (self->star_one, FILLED_ICON_NAME);
     case 0:
     default:
         break;
@@ -107,40 +106,41 @@ void update_rating(ExmRating *self)
 }
 
 static void
-exm_rating_class_init(ExmRatingClass *klass)
+exm_rating_class_init (ExmRatingClass *klass)
 {
-    GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    GObjectClass *object_class = G_OBJECT_CLASS (klass);
 
     object_class->finalize = exm_rating_finalize;
     object_class->get_property = exm_rating_get_property;
     object_class->set_property = exm_rating_set_property;
 
-    properties[PROP_RATING] = g_param_spec_int("rating",
-                                               "Rating",
-                                               "Rating",
-                                               0, G_MAXINT, 0,
-                                               G_PARAM_READWRITE);
+    properties [PROP_RATING]
+        = g_param_spec_int ("rating",
+                            "Rating",
+                            "Rating",
+                            0, G_MAXINT, 0,
+                            G_PARAM_READWRITE);
 
-    g_object_class_install_properties(object_class, N_PROPS, properties);
+    g_object_class_install_properties (object_class, N_PROPS, properties);
 
-    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS(klass);
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
 
-    gtk_widget_class_set_template_from_resource(widget_class, "/com/mattjakeman/ExtensionManager/exm-rating.ui");
+    gtk_widget_class_set_template_from_resource (widget_class, "/com/mattjakeman/ExtensionManager/exm-rating.ui");
 
-    gtk_widget_class_bind_template_child(widget_class, ExmRating, star_one);
-    gtk_widget_class_bind_template_child(widget_class, ExmRating, star_two);
-    gtk_widget_class_bind_template_child(widget_class, ExmRating, star_three);
-    gtk_widget_class_bind_template_child(widget_class, ExmRating, star_four);
-    gtk_widget_class_bind_template_child(widget_class, ExmRating, star_five);
+    gtk_widget_class_bind_template_child (widget_class, ExmRating, star_one);
+    gtk_widget_class_bind_template_child (widget_class, ExmRating, star_two);
+    gtk_widget_class_bind_template_child (widget_class, ExmRating, star_three);
+    gtk_widget_class_bind_template_child (widget_class, ExmRating, star_four);
+    gtk_widget_class_bind_template_child (widget_class, ExmRating, star_five);
 
-    gtk_widget_class_set_layout_manager_type(widget_class, GTK_TYPE_BIN_LAYOUT);
-    gtk_widget_class_set_css_name(widget_class, "rating");
+    gtk_widget_class_set_layout_manager_type (widget_class, GTK_TYPE_BIN_LAYOUT);
+    gtk_widget_class_set_css_name (widget_class, "rating");
 }
 
 static void
-exm_rating_init(ExmRating *self)
+exm_rating_init (ExmRating *self)
 {
-    gtk_widget_init_template(GTK_WIDGET(self));
+    gtk_widget_init_template (GTK_WIDGET (self));
 
-    update_rating(self);
+    update_rating (self);
 }

--- a/src/exm-rating.c
+++ b/src/exm-rating.c
@@ -13,92 +13,93 @@ struct _ExmRating
     GtkImage *star_five;
 };
 
-G_DEFINE_FINAL_TYPE (ExmRating, exm_rating, GTK_TYPE_WIDGET)
+G_DEFINE_FINAL_TYPE(ExmRating, exm_rating, GTK_TYPE_WIDGET)
 
-enum {
+enum
+{
     PROP_0,
     PROP_RATING,
     N_PROPS
 };
 
-static GParamSpec *properties [N_PROPS];
+static GParamSpec *properties[N_PROPS];
 
 ExmRating *
-exm_rating_new (void)
+exm_rating_new(void)
 {
-    return g_object_new (EXM_TYPE_RATING, NULL);
+    return g_object_new(EXM_TYPE_RATING, NULL);
 }
 
 static void
-exm_rating_finalize (GObject *object)
+exm_rating_finalize(GObject *object)
 {
     ExmRating *self = (ExmRating *)object;
 
-    G_OBJECT_CLASS (exm_rating_parent_class)->finalize (object);
+    G_OBJECT_CLASS(exm_rating_parent_class)->finalize(object);
 }
 
-void update_rating (ExmRating *self);
+void update_rating(ExmRating *self);
 
 static void
-exm_rating_get_property (GObject    *object,
-                         guint       prop_id,
-                         GValue     *value,
-                         GParamSpec *pspec)
+exm_rating_get_property(GObject *object,
+                        guint prop_id,
+                        GValue *value,
+                        GParamSpec *pspec)
 {
-    ExmRating *self = EXM_RATING (object);
+    ExmRating *self = EXM_RATING(object);
 
     switch (prop_id)
     {
     case PROP_RATING:
-        g_value_set_int (value, self->rating);
+        g_value_set_int(value, self->rating);
         break;
     default:
-        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
     }
 }
 
 static void
-exm_rating_set_property (GObject      *object,
-                         guint         prop_id,
-                         const GValue *value,
-                         GParamSpec   *pspec)
+exm_rating_set_property(GObject *object,
+                        guint prop_id,
+                        const GValue *value,
+                        GParamSpec *pspec)
 {
-    ExmRating *self = EXM_RATING (object);
+    ExmRating *self = EXM_RATING(object);
 
     switch (prop_id)
     {
     case PROP_RATING:
-        self->rating = g_value_get_int (value);
-        update_rating (self);
+        self->rating = g_value_get_int(value);
+        update_rating(self);
         break;
     default:
-        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
     }
 }
 
 #define FILLED_ICON_NAME "star-filled-rounded-symbolic"
 #define EMPTY_ICON_NAME "star-outline-rounded-symbolic"
 
-void update_rating (ExmRating *self)
+void update_rating(ExmRating *self)
 {
-    gtk_image_set_from_gressource (self->star_one, EMPTY_ICON_NAME);
-    gtk_image_set_from_gressource (self->star_two, EMPTY_ICON_NAME);
-    gtk_image_set_from_gressource (self->star_three, EMPTY_ICON_NAME);
-    gtk_image_set_from_gressource (self->star_four, EMPTY_ICON_NAME);
-    gtk_image_set_from_gressource (self->star_five, EMPTY_ICON_NAME);
+    gtk_image_set_from_icon_name(self->star_one, EMPTY_ICON_NAME);
+    gtk_image_set_from_icon_name(self->star_two, EMPTY_ICON_NAME);
+    gtk_image_set_from_icon_name(self->star_three, EMPTY_ICON_NAME);
+    gtk_image_set_from_icon_name(self->star_four, EMPTY_ICON_NAME);
+    gtk_image_set_from_icon_name(self->star_five, EMPTY_ICON_NAME);
 
     switch (self->rating)
     {
     case 5:
-        gtk_image_set_from_gressource (self->star_five, FILLED_ICON_NAME);
+        gtk_image_set_from_icon_name(self->star_five, FILLED_ICON_NAME);
     case 4:
-        gtk_image_set_from_gressource (self->star_four, FILLED_ICON_NAME);
+        gtk_image_set_from_icon_name(self->star_four, FILLED_ICON_NAME);
     case 3:
-        gtk_image_set_from_gressource (self->star_three, FILLED_ICON_NAME);
+        gtk_image_set_from_icon_name(self->star_three, FILLED_ICON_NAME);
     case 2:
-        gtk_image_set_from_gressource (self->star_two, FILLED_ICON_NAME);
+        gtk_image_set_from_icon_name(self->star_two, FILLED_ICON_NAME);
     case 1:
-        gtk_image_set_from_gressource (self->star_one, FILLED_ICON_NAME);
+        gtk_image_set_from_icon_name(self->star_one, FILLED_ICON_NAME);
     case 0:
     default:
         break;
@@ -106,41 +107,40 @@ void update_rating (ExmRating *self)
 }
 
 static void
-exm_rating_class_init (ExmRatingClass *klass)
+exm_rating_class_init(ExmRatingClass *klass)
 {
-    GObjectClass *object_class = G_OBJECT_CLASS (klass);
+    GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
     object_class->finalize = exm_rating_finalize;
     object_class->get_property = exm_rating_get_property;
     object_class->set_property = exm_rating_set_property;
 
-    properties [PROP_RATING]
-        = g_param_spec_int ("rating",
-                            "Rating",
-                            "Rating",
-                            0, G_MAXINT, 0,
-                            G_PARAM_READWRITE);
+    properties[PROP_RATING] = g_param_spec_int("rating",
+                                               "Rating",
+                                               "Rating",
+                                               0, G_MAXINT, 0,
+                                               G_PARAM_READWRITE);
 
-    g_object_class_install_properties (object_class, N_PROPS, properties);
+    g_object_class_install_properties(object_class, N_PROPS, properties);
 
-    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS(klass);
 
-    gtk_widget_class_set_template_from_resource (widget_class, "/com/mattjakeman/ExtensionManager/exm-rating.ui");
+    gtk_widget_class_set_template_from_resource(widget_class, "/com/mattjakeman/ExtensionManager/exm-rating.ui");
 
-    gtk_widget_class_bind_template_child (widget_class, ExmRating, star_one);
-    gtk_widget_class_bind_template_child (widget_class, ExmRating, star_two);
-    gtk_widget_class_bind_template_child (widget_class, ExmRating, star_three);
-    gtk_widget_class_bind_template_child (widget_class, ExmRating, star_four);
-    gtk_widget_class_bind_template_child (widget_class, ExmRating, star_five);
+    gtk_widget_class_bind_template_child(widget_class, ExmRating, star_one);
+    gtk_widget_class_bind_template_child(widget_class, ExmRating, star_two);
+    gtk_widget_class_bind_template_child(widget_class, ExmRating, star_three);
+    gtk_widget_class_bind_template_child(widget_class, ExmRating, star_four);
+    gtk_widget_class_bind_template_child(widget_class, ExmRating, star_five);
 
-    gtk_widget_class_set_layout_manager_type (widget_class, GTK_TYPE_BIN_LAYOUT);
-    gtk_widget_class_set_css_name (widget_class, "rating");
+    gtk_widget_class_set_layout_manager_type(widget_class, GTK_TYPE_BIN_LAYOUT);
+    gtk_widget_class_set_css_name(widget_class, "rating");
 }
 
 static void
-exm_rating_init (ExmRating *self)
+exm_rating_init(ExmRating *self)
 {
-    gtk_widget_init_template (GTK_WIDGET (self));
+    gtk_widget_init_template(GTK_WIDGET(self));
 
-    update_rating (self);
+    update_rating(self);
 }

--- a/src/exm-rating.c
+++ b/src/exm-rating.c
@@ -81,24 +81,24 @@ exm_rating_set_property (GObject      *object,
 
 void update_rating (ExmRating *self)
 {
-    gtk_image_set_from_icon_name (self->star_one, EMPTY_ICON_NAME);
-    gtk_image_set_from_icon_name (self->star_two, EMPTY_ICON_NAME);
-    gtk_image_set_from_icon_name (self->star_three, EMPTY_ICON_NAME);
-    gtk_image_set_from_icon_name (self->star_four, EMPTY_ICON_NAME);
-    gtk_image_set_from_icon_name (self->star_five, EMPTY_ICON_NAME);
+    gtk_image_set_from_gressource (self->star_one, EMPTY_ICON_NAME);
+    gtk_image_set_from_gressource (self->star_two, EMPTY_ICON_NAME);
+    gtk_image_set_from_gressource (self->star_three, EMPTY_ICON_NAME);
+    gtk_image_set_from_gressource (self->star_four, EMPTY_ICON_NAME);
+    gtk_image_set_from_gressource (self->star_five, EMPTY_ICON_NAME);
 
     switch (self->rating)
     {
     case 5:
-        gtk_image_set_from_icon_name (self->star_five, FILLED_ICON_NAME);
+        gtk_image_set_from_gressource (self->star_five, FILLED_ICON_NAME);
     case 4:
-        gtk_image_set_from_icon_name (self->star_four, FILLED_ICON_NAME);
+        gtk_image_set_from_gressource (self->star_four, FILLED_ICON_NAME);
     case 3:
-        gtk_image_set_from_icon_name (self->star_three, FILLED_ICON_NAME);
+        gtk_image_set_from_gressource (self->star_three, FILLED_ICON_NAME);
     case 2:
-        gtk_image_set_from_icon_name (self->star_two, FILLED_ICON_NAME);
+        gtk_image_set_from_gressource (self->star_two, FILLED_ICON_NAME);
     case 1:
-        gtk_image_set_from_icon_name (self->star_one, FILLED_ICON_NAME);
+        gtk_image_set_from_gressource (self->star_one, FILLED_ICON_NAME);
     case 0:
     default:
         break;

--- a/src/exm.gresource.xml
+++ b/src/exm.gresource.xml
@@ -27,7 +27,6 @@
     <file preprocess="xml-stripblanks" alias="globe-symbolic.svg">../data/icons/hicolor/scalable/actions/globe-symbolic.svg</file>
     <file preprocess="xml-stripblanks" alias="go-next-symbolic.svg">../data/icons/hicolor/scalable/actions/go-next-symbolic.svg</file>
     <file preprocess="xml-stripblanks" alias="go-previous-symbolic.svg">../data/icons/hicolor/scalable/actions/go-previous-symbolic.svg</file>
-    <file preprocess="xml-stripblanks" alias="external-link-symbolic.svg">../data/icons/hicolor/scalable/actions/external-link-symbolic.svg</file>
     <file preprocess="xml-stripblanks" alias="puzzle-piece-symbolic.svg">../data/icons/hicolor/scalable/actions/puzzle-piece-symbolic.svg</file>
     <file preprocess="xml-stripblanks" alias="settings-symbolic.svg">../data/icons/hicolor/scalable/actions/settings-symbolic.svg</file>
     <file preprocess="xml-stripblanks" alias="software-update-available-symbolic.svg">../data/icons/hicolor/scalable/actions/software-update-available-symbolic.svg</file>

--- a/src/exm.gresource.xml
+++ b/src/exm.gresource.xml
@@ -17,7 +17,7 @@
     <file>style.css</file>
   </gresource>
 
-  <gresource prefix="/com/github/GradienceTeam/Gradience/icons/scalable/actions/">
+  <gresource prefix="/com/mattjakeman/ExtensionManager/icons/scalable/actions/">
     <file preprocess="xml-stripblanks" alias="star-filled-rounded-symbolic.svg">../data/icons/hicolor/scalable/actions/star-filled-rounded-symbolic.svg</file>
     <file preprocess="xml-stripblanks" alias="star-outline-rounded-symbolic.svg">../data/icons/hicolor/scalable/actions/star-outline-rounded-symbolic.svg</file>
     <file preprocess="xml-stripblanks" alias="clock-alt-symbolic.svg">../data/icons/hicolor/scalable/actions/clock-alt-symbolic.svg</file>

--- a/src/exm.gresource.xml
+++ b/src/exm.gresource.xml
@@ -16,4 +16,20 @@
     <file>release-notes.txt</file>
     <file>style.css</file>
   </gresource>
+
+  <gresource prefix="/com/github/GradienceTeam/Gradience/icons/scalable/actions/">
+    <file preprocess="xml-stripblanks" alias="star-filled-rounded-symbolic.svg">../data/icons/hicolor/scalable/actions/star-filled-rounded-symbolic.svg</file>
+    <file preprocess="xml-stripblanks" alias="star-outline-rounded-symbolic.svg">../data/icons/hicolor/scalable/actions/star-outline-rounded-symbolic.svg</file>
+    <file preprocess="xml-stripblanks" alias="clock-alt-symbolic.svg">../data/icons/hicolor/scalable/actions/clock-alt-symbolic.svg</file>
+    <file preprocess="xml-stripblanks" alias="dialog-question-symbolic.svg">../data/icons/hicolor/scalable/actions/dialog-question-symbolic.svg</file>
+    <file preprocess="xml-stripblanks" alias="error-symbolic.svg">../data/icons/hicolor/scalable/actions/error-symbolic.svg</file>
+    <file preprocess="xml-stripblanks" alias="external-link-symbolic.svg">../data/icons/hicolor/scalable/actions/external-link-symbolic.svg</file>
+    <file preprocess="xml-stripblanks" alias="globe-symbolic.svg">../data/icons/hicolor/scalable/actions/globe-symbolic.svg</file>
+    <file preprocess="xml-stripblanks" alias="go-next-symbolic.svg">../data/icons/hicolor/scalable/actions/go-next-symbolic.svg</file>
+    <file preprocess="xml-stripblanks" alias="go-previous-symbolic.svg">../data/icons/hicolor/scalable/actions/go-previous-symbolic.svg</file>
+    <file preprocess="xml-stripblanks" alias="external-link-symbolic.svg">../data/icons/hicolor/scalable/actions/external-link-symbolic.svg</file>
+    <file preprocess="xml-stripblanks" alias="puzzle-piece-symbolic.svg">../data/icons/hicolor/scalable/actions/puzzle-piece-symbolic.svg</file>
+    <file preprocess="xml-stripblanks" alias="settings-symbolic.svg">../data/icons/hicolor/scalable/actions/settings-symbolic.svg</file>
+    <file preprocess="xml-stripblanks" alias="software-update-available-symbolic.svg">../data/icons/hicolor/scalable/actions/software-update-available-symbolic.svg</file>
+  </gresource>
 </gresources>


### PR DESCRIPTION
Icons are currently installed in datadir, it can cause conflict with others apps (maybe they are using the same icons). So, i move icons to  `gressource`