### PR TITLE
Post release version bump and misc changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     name: "Flatpak"
     runs-on: ubuntu-latest
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-42
+      image: bilelmoussaoui/flatpak-github-actions:gnome-nightly
       options: --privileged
     steps:
     - uses: actions/checkout@v2

--- a/com.mattjakeman.ExtensionManager.Devel.json
+++ b/com.mattjakeman.ExtensionManager.Devel.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "com.mattjakeman.ExtensionManager.Devel",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "42",
+    "runtime-version" : "master",
     "sdk" : "org.gnome.Sdk",
     "command" : "extension-manager",
     "finish-args" : [

--- a/com.mattjakeman.ExtensionManager.Devel.json
+++ b/com.mattjakeman.ExtensionManager.Devel.json
@@ -33,7 +33,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler.git",
-                    "commit": "6576e0283757a58f92227811874406e025dbd98a"
+                    "commit": "87cedc2c7e48b01dc1b07aef937e2fe02111b18c",
+                    "tag": "v0.2.0"
                 }
             ]
         },

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('extension-manager', 'c',
-          version: '0.3.2',
+          version: '0.4.0',
     meson_version: '>= 0.59.0',
   default_options: [ 'warning_level=2',
                      'c_std=gnu11',

--- a/src/exm-application.c
+++ b/src/exm-application.c
@@ -110,18 +110,20 @@ exm_application_show_about (GSimpleAction *action,
 
     window = gtk_application_get_active_window (GTK_APPLICATION (self));
 
-    gtk_show_about_dialog (window,
-                           "program-name", program_name,
-                           "authors", authors,
-                           // TRANSLATORS: 'Name <email@domain.com>' or 'Name https://website.example'
-                           "translator-credits", _("translator-credits"),
-                           "comments", _("A very simple tool for browsing, downloading, and managing GNOME shell extensions."),
+    adw_show_about_window (window,
+                           "application-name", program_name,
+                           "application-icon", APP_ID,
+                           "developer-name", "Matthew Jakeman",
                            "version", APP_VERSION,
-                           "copyright", "Copyright © Matthew Jakeman 2021",
-                           "license-type", GTK_LICENSE_GPL_3_0,
-                           "logo-icon-name", APP_ID,
+                           "comments", _("A very simple tool for browsing, downloading, and managing GNOME shell extensions."),
                            "website", "https://github.com/mjakeman/extension-manager",
-                           "website-label", _("Project Homepage"),
+                           "support-url", "https://github.com/mjakeman/extension-manager/discussions",
+                           "issue-url", "https://github.com/mjakeman/extension-manager/issues",
+                           // "debug-info", "<system stats>",
+                           "developers", authors,
+                           "translator-credits", _("translator-credits"),
+                           "copyright", "© 2022 Matthew Jakeman",
+                           "license-type", GTK_LICENSE_GPL_3_0,
                            NULL);
 }
 


### PR DESCRIPTION
 - Bump version to 0.4
 - Pin blueprint-compiler at version 0.2.0
 - Use GNOME nightly SDK
 - Port about dialog to AdwAboutWindow