### PR TITLE
Implement Placeholders

### DIFF
--- a/src/exm-installed-page.c
+++ b/src/exm-installed-page.c
@@ -336,6 +336,9 @@ create_user_placeholder ()
     gtk_widget_set_valign (button, GTK_ALIGN_CENTER);
     gtk_widget_set_halign (button, GTK_ALIGN_CENTER);
 
+    gtk_actionable_set_action_name (GTK_ACTIONABLE (button), "win.show-page");
+    gtk_actionable_set_action_target (GTK_ACTIONABLE (button), "s", "browse");
+
     adw_action_row_set_icon_name (ADW_ACTION_ROW (row), "globe-symbolic");
     adw_preferences_row_set_title (ADW_PREFERENCES_ROW (row),
                                    _("There are no user extensions installed."));

--- a/src/exm-installed-page.c
+++ b/src/exm-installed-page.c
@@ -325,6 +325,39 @@ exm_installed_page_class_init (ExmInstalledPageClass *klass)
     gtk_widget_class_set_layout_manager_type (widget_class, GTK_TYPE_BIN_LAYOUT);
 }
 
+static GtkWidget *
+create_user_placeholder ()
+{
+    GtkWidget *row, *button;
+
+    row = adw_action_row_new ();
+    button = gtk_button_new_with_label (_("Browse"));
+
+    gtk_widget_set_valign (button, GTK_ALIGN_CENTER);
+    gtk_widget_set_halign (button, GTK_ALIGN_CENTER);
+
+    adw_action_row_set_icon_name (ADW_ACTION_ROW (row), "globe-symbolic");
+    adw_preferences_row_set_title (ADW_PREFERENCES_ROW (row),
+                                   _("There are no user extensions installed."));
+    adw_action_row_add_suffix (ADW_ACTION_ROW (row), button);
+
+    return row;
+}
+
+static GtkWidget *
+create_system_placeholder ()
+{
+    GtkWidget *row;
+
+    row = adw_action_row_new ();
+    adw_action_row_set_icon_name (ADW_ACTION_ROW (row), "settings-symbolic");
+    adw_preferences_row_set_title (ADW_PREFERENCES_ROW (row),
+                                   _("There are no system extensions installed."));
+
+    return row;
+
+}
+
 static void
 exm_installed_page_init (ExmInstalledPage *self)
 {
@@ -344,4 +377,12 @@ exm_installed_page_init (ExmInstalledPage *self)
                      G_SETTINGS_BIND_GET);
 
     g_object_unref (settings);
+
+    gtk_list_box_set_placeholder (self->user_list_box,
+                                  create_user_placeholder ());
+
+    gtk_list_box_set_placeholder (self->system_list_box,
+                                  create_system_placeholder ());
+
+
 }

--- a/src/exm-window.c
+++ b/src/exm-window.c
@@ -43,6 +43,7 @@ struct _ExmWindow
     GtkWidget            *main_view;
     ExmDetailView        *detail_view;
     AdwViewSwitcherTitle *title;
+    AdwViewStack         *view_stack;
 };
 
 G_DEFINE_TYPE (ExmWindow, exm_window, ADW_TYPE_APPLICATION_WINDOW)
@@ -262,6 +263,21 @@ extension_install (GtkWidget  *widget,
 }
 
 static void
+show_page (GtkWidget  *widget,
+           const char *action_name,
+           GVariant   *param)
+{
+    ExmWindow *self;
+    char *target;
+
+    g_variant_get (param, "s", &target);
+
+    self = EXM_WINDOW (widget);
+
+    adw_view_stack_set_visible_child_name (self->view_stack, target);
+}
+
+static void
 show_view (GtkWidget  *widget,
            const char *action_name,
            GVariant   *param)
@@ -328,6 +344,7 @@ exm_window_class_init (ExmWindowClass *klass)
     gtk_widget_class_bind_template_child (widget_class, ExmWindow, main_view);
     gtk_widget_class_bind_template_child (widget_class, ExmWindow, detail_view);
     gtk_widget_class_bind_template_child (widget_class, ExmWindow, title);
+    gtk_widget_class_bind_template_child (widget_class, ExmWindow, view_stack);
 
     // TODO: Refactor ExmWindow into a separate ExmController and supply the
     // necessary actions/methods/etc in there. A reference to this new object can
@@ -338,6 +355,7 @@ exm_window_class_init (ExmWindowClass *klass)
     gtk_widget_class_install_action (widget_class, "ext.open-prefs", "s", extension_open_prefs);
     gtk_widget_class_install_action (widget_class, "win.show-detail", "s", show_view);
     gtk_widget_class_install_action (widget_class, "win.show-main", NULL, show_view);
+    gtk_widget_class_install_action (widget_class, "win.show-page", "s", show_page);
     gtk_widget_class_install_action (widget_class, "win.show-release-notes", NULL, show_release_notes);
 }
 


### PR DESCRIPTION
When we have no extensions visible, implement a placeholder.

<img width="824" alt="image" src="https://user-images.githubusercontent.com/12368711/190821396-fa30c78b-9a64-4ff8-b555-04fa23eca78a.png">

Fixes #63 