### PR TITLE
add mnemonics to view switcher

### DIFF
--- a/src/exm-window.blp
+++ b/src/exm-window.blp
@@ -37,7 +37,8 @@ template ExmWindow : Adw.ApplicationWindow {
 
 					   Adw.ViewStackPage {
 						  name: "installed";
-						  title: C_("Navigation", "Installed");
+						  title: C_("Navigation", "Ins_talled");
+						  use-underline: true;
 						  icon-name: "puzzle-piece-symbolic";
 
 						  child: .ExmInstalledPage installed_page {};
@@ -45,7 +46,8 @@ template ExmWindow : Adw.ApplicationWindow {
 
 					  Adw.ViewStackPage {
 						  name: "browse";
-						  title: C_("Navigation", "Browse");
+						  title: C_("Navigation", "_Browse");
+						  use-underline: true;
 						  icon-name: "globe-symbolic";
 
 						  child: .ExmBrowsePage browse_page {};


### PR DESCRIPTION
I added mnemonics (or access keys) to the view switcher buttons "Installed" and "Browse" in the application window.

Note that it'd be necessary to alter the translations in order to make them actually use the mnemonics.

Thanks for developing!