### PR TITLE
metainfo: Remove period from the summary

### DIFF
--- a/data/com.mattjakeman.ExtensionManager.metainfo.xml.in.in
+++ b/data/com.mattjakeman.ExtensionManager.metainfo.xml.in.in
@@ -4,7 +4,7 @@
 	<metadata_license>CC0-1.0</metadata_license>
 	<project_license>GPL-3.0-or-later</project_license>
   <name>@app_title@</name>
-  <summary>Browse, install, and manage GNOME Shell Extensions.</summary>
+  <summary>Browse, install, and manage GNOME Shell Extensions</summary>
   <content_rating type="oars-1.1" />
   <developer_name translatable="no">Matthew Jakeman</developer_name>
 	<description>


### PR DESCRIPTION
Application summary in AppStream metainfo, just like Comment in a desktop file, should not end with a period. See the [example file](https://freedesktop.org/software/appstream/docs/chap-Quickstart.html#qsr-app-example).

/cc @mjakeman