### PR TITLE
Changes to error/support log generation

### DIFF
--- a/com.mattjakeman.ExtensionManager.Devel.json
+++ b/com.mattjakeman.ExtensionManager.Devel.json
@@ -33,8 +33,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler.git",
-                    "commit": "87cedc2c7e48b01dc1b07aef937e2fe02111b18c",
-                    "tag": "v0.2.0"
+                    "commit": "9adcab2d225fd6435edc85c72a0b67e33880e00b",
+                    "tag": "v0.6.0"
                 }
             ]
         },
@@ -70,7 +70,7 @@
             "build-options" : {
             	"no-debuginfo" : true
             },
-            "config-opts" : [ "-Ddevelopment=true" ],
+            "config-opts" : [ "-Ddevelopment=true", "-Dpackage=Flatpak", "-Ddistributor=Matthew\ Jakeman", "-Dofficial=false" ],
             "sources" : [
                 {
                     "type" : "dir",

--- a/com.mattjakeman.ExtensionManager.Devel.json
+++ b/com.mattjakeman.ExtensionManager.Devel.json
@@ -70,7 +70,7 @@
             "build-options" : {
             	"no-debuginfo" : true
             },
-            "config-opts" : [ "-Ddevelopment=true", "-Dpackage=Flatpak", "-Ddistributor=Matthew\ Jakeman", "-Dofficial=true" ],
+            "config-opts" : [ "-Ddevelopment=true", "-Dpackage=Flatpak", "-Ddistributor=mjakeman", "-Dofficial=true" ],
             "sources" : [
                 {
                     "type" : "dir",

--- a/com.mattjakeman.ExtensionManager.Devel.json
+++ b/com.mattjakeman.ExtensionManager.Devel.json
@@ -70,7 +70,7 @@
             "build-options" : {
             	"no-debuginfo" : true
             },
-            "config-opts" : [ "-Ddevelopment=true", "-Dpackage=Flatpak", "-Ddistributor=Matthew\ Jakeman", "-Dofficial=false" ],
+            "config-opts" : [ "-Ddevelopment=true", "-Dpackage=Flatpak", "-Ddistributor=Matthew\ Jakeman", "-Dofficial=true" ],
             "sources" : [
                 {
                     "type" : "dir",

--- a/meson.build
+++ b/meson.build
@@ -21,6 +21,9 @@ config_h.set_quoted('APP_VERSION', meson.project_version())
 config_h.set_quoted('GETTEXT_PACKAGE', 'extension-manager')
 config_h.set_quoted('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
 config_h.set_quoted('APP_ID', app_id)
+config_h.set_quoted('PKG_NAME', get_option('package'))
+config_h.set_quoted('PKG_DISTRIBUTOR', get_option('distributor'))
+config_h.set10('IS_OFFICIAL', get_option('official'))
 config_h.set10('IS_DEVEL', get_option('development'))
 configure_file(
   output: 'exm-config.h',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,20 @@
-option('development', type: 'boolean', value: false, description: 'Produce a development build')
+option('development',
+	type: 'boolean',
+	value: false,
+	description: 'Produce a development build')
+
+option('official',
+	type: 'boolean',
+	value: false,
+	description: 'Whether this is an official upstream package')
+
+# Will be shown in error messages
+option('package',
+	type: 'string',
+	value: 'Unknown Package',
+	description: 'The package format being built (e.g. "Flatpak")')
+
+option('distributor',
+	type: 'string',
+	value: 'Unknown Author',
+	description: 'The package distributor (e.g. "Your Name <optional email>")')

--- a/src/exm-error-dialog.blp
+++ b/src/exm-error-dialog.blp
@@ -2,8 +2,8 @@ using Gtk 4.0;
 using Adw 1;
 
 template ExmErrorDialog : Adw.Window {
-  default-width: 400;
-  default-height: 400;
+  default-width: 450;
+  default-height: 450;
   title: _("Error Report");
 
   Gtk.Box {
@@ -18,13 +18,21 @@ template ExmErrorDialog : Adw.Window {
       orientation: vertical;
       spacing: 16;
 
+      margin-start: 8;
+      margin-end: 8;
+
       Gtk.Image {
         icon-name: "error-symbolic";
         icon-size: large;
       }
 
       Gtk.Label {
-        label: _("An unexpected error occurred in Extension Manager. Please open a new issue and attach the following information:");
+        styles ["heading"]
+        label: _("An unexpected error occurred in Extension Manager.");
+      }
+
+      Gtk.Label instructions {
+        xalign: 0;
         wrap: true;
       }
 

--- a/src/exm-error-dialog.c
+++ b/src/exm-error-dialog.c
@@ -101,6 +101,7 @@ exm_error_dialog_set_property (GObject      *object,
         GString *string_builder = g_string_new ("Support Log\n");
         g_string_append_printf (string_builder, "----\n");
         g_string_append_printf (string_builder, "Version: %s\n", APP_VERSION);
+        g_string_append_printf (string_builder, "Development: %s\n", IS_DEVEL ? "Yes" : "No");
         g_string_append_printf (string_builder, "Package Format: %s\n", PKG_NAME);
         g_string_append_printf (string_builder, "Status: %s\n", IS_OFFICIAL ? "Official" : "Third Party");
         g_string_append_printf (string_builder, "----\n");

--- a/src/exm-error-dialog.c
+++ b/src/exm-error-dialog.c
@@ -20,6 +20,8 @@
 
 #include "exm-error-dialog.h"
 
+#include "exm-config.h"
+
 #include <glib/gi18n.h>
 
 struct _ExmErrorDialog
@@ -28,6 +30,8 @@ struct _ExmErrorDialog
 
     char *error_string;
     GtkTextView *text_view;
+    GtkLabel *instructions;
+    GtkButton *new_issue_button;
 };
 
 G_DEFINE_FINAL_TYPE (ExmErrorDialog, exm_error_dialog, ADW_TYPE_WINDOW)
@@ -93,7 +97,15 @@ exm_error_dialog_set_property (GObject      *object,
             g_free (self->error_string);
 
         self->error_string = g_strdup (g_value_get_string (value));
-        gtk_text_buffer_set_text (buffer, self->error_string, -1);
+
+        GString *string_builder = g_string_new ("Support Log\n");
+        g_string_append_printf (string_builder, "----\n");
+        g_string_append_printf (string_builder, "Version: %s\n", APP_VERSION);
+        g_string_append_printf (string_builder, "Package Format: %s\n", PKG_NAME);
+        g_string_append_printf (string_builder, "Status: %s\n", IS_OFFICIAL ? "Official" : "Third Party");
+        g_string_append_printf (string_builder, "----\n");
+        g_string_append_printf (string_builder, "%s", self->error_string);
+        gtk_text_buffer_set_text (buffer, g_string_free (string_builder, FALSE), -1);
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -147,6 +159,8 @@ exm_error_dialog_class_init (ExmErrorDialogClass *klass)
     gtk_widget_class_set_template_from_resource (widget_class, "/com/mattjakeman/ExtensionManager/exm-error-dialog.ui");
 
     gtk_widget_class_bind_template_child (widget_class, ExmErrorDialog, text_view);
+    gtk_widget_class_bind_template_child (widget_class, ExmErrorDialog, instructions);
+    gtk_widget_class_bind_template_child (widget_class, ExmErrorDialog, new_issue_button);
 
     gtk_widget_class_bind_template_callback (widget_class, on_copy_button_clicked);
     gtk_widget_class_bind_template_callback (widget_class, on_new_issue_button_clicked);
@@ -156,5 +170,18 @@ static void
 exm_error_dialog_init (ExmErrorDialog *self)
 {
     gtk_widget_init_template (GTK_WIDGET (self));
+
+    gtk_label_set_use_markup (self->instructions, TRUE);
+
+#if IS_OFFICIAL
+    gtk_label_set_text (self->instructions, _("Please open a new issue and attach the following information:"));
+    gtk_widget_set_visible (GTK_WIDGET (self->new_issue_button), TRUE);
+#else
+    // Translators: '%s' = Name of Distributor (e.g. "Packager123")
+    char *text = g_markup_printf_escaped (_("You are using a third-party build of Extension Manager. Please <span weight=\"bold\">contact the package distributor (%s) first</span> before filing an issue. Be sure to attach the following information:"), PKG_DISTRIBUTOR);
+    gtk_label_set_markup (self->instructions, text);
+    gtk_widget_set_visible (GTK_WIDGET (self->new_issue_button), FALSE);
+    g_free (text);
+#endif
 }
 


### PR DESCRIPTION
Since a lot of third-party packages are doing interesting and funky things, differentiate between upstream and third-party packages in the support log.

We'll still take bug reports for third-party packages, but users are encouraged to go to the distribution first since it's (probably) not an upstream problem.