### PR TITLE
upgrade-assistant: don't scroll horizontally on results

### DIFF
--- a/src/exm-upgrade-assistant.blp
+++ b/src/exm-upgrade-assistant.blp
@@ -75,6 +75,7 @@ template ExmUpgradeAssistant : Adw.Window {
       Gtk.StackPage results {
       	name: "results";
         child: Gtk.ScrolledWindow {
+		      hscrollbar-policy: never;
 		      child: Adw.Clamp {
 				    child: Gtk.Box {
 				    	styles ["content"]


### PR DESCRIPTION
Unless you have a rather strange idea about how that scroll should work, I honestly think you don't want it to be able to scroll horizontally.

![image](https://user-images.githubusercontent.com/18204745/230833691-ce5acdcc-063b-43d2-9530-112fb936d28c.png)
