### PR TITLE
exm-backtrace.c: Explicitly include stdint.h for uintptr_t usage

### DIFF
--- a/src/exm-backtrace.c
+++ b/src/exm-backtrace.c
@@ -21,6 +21,7 @@
 #include "exm-backtrace.h"
 
 #include <glib.h>
+#include <stdint.h>
 
 #include <backtrace-supported.h>
 #include <backtrace.h>


### PR DESCRIPTION
The file uses type `uintptr_t` from `stdint.h`, which is indirectly included by `backtrace.h`.  Even so, the file should unconditionally include `stdint.h` just in case `backtrace.h` no longer includes `stdint.h` in the future.