### PR TITLE
CI: bump actions version, fix Node 12 deprecation warning under action runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,8 +11,8 @@ jobs:
       image: bilelmoussaoui/flatpak-github-actions:gnome-nightly
       options: --privileged
     steps:
-    - uses: actions/checkout@v2
-    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
+    - uses: actions/checkout@v3
+    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v6.1
       with:
         bundle: extension-manager.flatpak
         manifest-path: com.mattjakeman.ExtensionManager.Devel.json


### PR DESCRIPTION
## Changes

- Bump `actions/checkout` from `v2` (Node 12) to `v3` (Node 16). [Node 12 reached eol recently, GitHub removed support for it last month, currently, all runners default to Node 16 even if the file has Node 12 specified.]
- Bump `bilelmoussaoui/flatpak-github-actions/flatpak-builder` to `v6.1`.