### PR TITLE
Use `active` instead of `state` for global toggle

### DIFF
--- a/src/exm-installed-page.c
+++ b/src/exm-installed-page.c
@@ -271,7 +271,7 @@ on_bind_manager (ExmInstalledPage *self)
     g_object_bind_property (self->manager,
                             "extensions-enabled",
                             self->global_toggle,
-                            "state",
+                            "active",
                             G_BINDING_BIDIRECTIONAL|G_BINDING_SYNC_CREATE);
 
     g_object_bind_property (self->manager,


### PR DESCRIPTION
Closes https://github.com/mjakeman/extension-manager/issues/388

[Screencast from 2023-06-25 16-20-03.webm](https://github.com/mjakeman/extension-manager/assets/50847364/47c967c0-162b-477e-b737-b2146b69eab6)
