### PR TITLE
Make libbacktrace an optional dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -25,6 +25,7 @@ config_h.set_quoted('PKG_NAME', get_option('package'))
 config_h.set_quoted('PKG_DISTRIBUTOR', get_option('distributor'))
 config_h.set10('IS_OFFICIAL', get_option('official'))
 config_h.set10('IS_DEVEL', get_option('development'))
+config_h.set10('WITH_BACKTRACE', get_option('backtrace'))
 configure_file(
   output: 'exm-config.h',
   configuration: config_h,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,6 +8,11 @@ option('official',
 	value: false,
 	description: 'Whether this is an official upstream package')
 
+option('backtrace',
+    type: 'boolean',
+    value: true,
+    description: 'Whether the package is built with backtrace support')
+
 # Will be shown in error messages
 option('package',
 	type: 'string',

--- a/src/exm-application.c
+++ b/src/exm-application.c
@@ -201,11 +201,13 @@ exm_application_show_about (GSimpleAction *action,
                                         GTK_LICENSE_MPL_2_0,
                                         NULL);
 
+#if WITH_BACKTRACE
     adw_about_window_add_legal_section (ADW_ABOUT_WINDOW (about_window),
                                         "libbacktrace",
                                         "Copyright (C) 2012-2016 Free Software Foundation, Inc.",
                                         GTK_LICENSE_BSD_3,
                                         NULL);
+#endif
 
     adw_about_window_add_legal_section (ADW_ABOUT_WINDOW (about_window),
                                         "blueprint",

--- a/src/exm-backtrace.c
+++ b/src/exm-backtrace.c
@@ -18,15 +18,21 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
+#include "exm-config.h"
+
 #include "exm-backtrace.h"
 
 #include <glib.h>
 #include <stdint.h>
 
+#if WITH_BACKTRACE
 #include <backtrace-supported.h>
 #include <backtrace.h>
+#endif
 
+#if WITH_BACKTRACE
 static struct backtrace_state *state = NULL;
+#endif
 
 static void
 exm_backtrace_error_cb (void       *data,
@@ -54,18 +60,25 @@ exm_backtrace_full_cb (GString    *string_builder,
 void
 exm_backtrace_init (char *filename)
 {
-#ifdef BACKTRACE_SUPPORTED
+#if WITH_BACKTRACE
+
+# ifdef BACKTRACE_SUPPORTED
     state = backtrace_create_state (filename, 0,
                                     exm_backtrace_error_cb,
                                     NULL);
-#else
+# else
     g_warning ("Backtraces are not supported.\n");
+# endif
+
+#else
+    g_info ("Backtraces were not enabled at build time.\n");
 #endif
 }
 
 char *
 exm_backtrace_print ()
 {
+#if WITH_BACKTRACE
     GString *string_builder;
 
     if (!state)
@@ -82,4 +95,8 @@ exm_backtrace_print ()
                     string_builder);
 
     return g_string_free (string_builder, FALSE);
+#else
+    g_critical ("Backtraces were not enabled at build time.\n");
+    return NULL;
+#endif
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -29,7 +29,7 @@ exm_sources = [
 ]
 
 cc = meson.get_compiler('c')
-libbacktrace_dep = cc.find_library('backtrace', required: true)
+libbacktrace_dep = cc.find_library('backtrace', required: get_option('backtrace'))
 
 exm_deps = [
   dependency('gtk4'),
@@ -37,9 +37,12 @@ exm_deps = [
   dependency('gio-unix-2.0'),
   dependency('json-glib-1.0'),
   dependency('libsoup-3.0'),
-  dependency('text-engine-0.1'),
-  libbacktrace_dep
+  dependency('text-engine-0.1')
 ]
+
+if libbacktrace_dep.found()
+  exm_deps += libbacktrace_dep
+endif
 
 gnome = import('gnome')
 


### PR DESCRIPTION
libbacktrace is not available in some distributions where Extension Manager is available as a native package, e.g. [Gentoo], [Debian].  Yet the backtraces that libbacktrace helps to collect are vital information for a crash report.

To help both these distributions continue shipping Extension Manager as a native package and users who install this app via Flathub report crashes with backtraces, I have created this patch to make libbacktrace an optional dependency.  It introduces a new `backtrace` Meson boolean option, which controls whether Extension Manager is to be built with libbacktrace.  It is set to `true` by default, so existing build pipelines, e.g. [this repo's GitHub Action workflow](https://github.com/mjakeman/extension-manager/actions/workflows/main.yml), behave the same as before. Folks who wish to build Extension Manager without libbacktrace can do it by setting `-Dbacktrace=false` in Meson command-line options.

I [have tested](https://gitweb.gentoo.org/repo/proj/guru.git/tree/gnome-extra/extension-manager/files/extension-manager-0.4.1-make-libbacktrace-optional.patch) this patch through the Gentoo GURU package for Extension Manager, which I maintain, for about a month now without any observation of issues.

If better names and string descriptions should be used for the Meson option (`backtrace`), the preprocessor macro (`WITH_BACKTRACE`), or the log messages, please feel free to suggest, and I am willing to update this patch using them.

[Gentoo]: https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=c99e8159e6cb8705227aab759359c158f52b64bd
[Debian]: https://salsa.debian.org/gnome-team/gnome-shell-extension-manager/-/commit/a7cccc5486ebeca2597aeab2ea5d6c74b17488b0