### PR TITLE
Use proper margins for icons in local extensions list

### DIFF
--- a/src/exm-extension-row.blp
+++ b/src/exm-extension-row.blp
@@ -32,6 +32,9 @@ template ExmExtensionRow : Adw.ExpanderRow {
 		valign: center;
 		halign: center;
 
+		margin-start: 9;
+		margin-end: 9;
+
 		visible: false;
 
 		tooltip-text: _("An error occurred while loading this extension");

--- a/src/exm-extension-row.blp
+++ b/src/exm-extension-row.blp
@@ -64,6 +64,9 @@ template ExmExtensionRow : Adw.ExpanderRow {
 		valign: center;
 		halign: center;
 
+		margin-start: 9;
+		margin-end: 9;
+
 		visible: false;
 
 		tooltip-text: _("A newer version of this extension is available");

--- a/src/exm-extension-row.blp
+++ b/src/exm-extension-row.blp
@@ -45,6 +45,9 @@ template ExmExtensionRow : Adw.ExpanderRow {
 		valign: center;
 		halign: center;
 
+		margin-start: 9;
+		margin-end: 9;
+
 		visible: false;
 
 		tooltip-text: _("This extension is incompatible with your current version of GNOME");


### PR DESCRIPTION
This pull request adds margins to out-of-date, error, update icon in local installed extensions list to align it with preferences button.

Result of this PR:
![Untitled](https://github.com/mjakeman/extension-manager/assets/47825679/b2ad0359-82af-4c2e-8d46-d4cd0764889c)
