### PR TITLE
Replace deprecated methods and widgets

### DIFF
--- a/src/exm-browse-page.c
+++ b/src/exm-browse-page.c
@@ -144,10 +144,7 @@ static void
 update_load_more_btn (ExmBrowsePage *self)
 {
     // Hide button if we are the last page
-    if (self->current_page == self->max_pages)
-        gtk_widget_hide (self->more_results_btn);
-    else
-        gtk_widget_show (self->more_results_btn);
+    gtk_widget_set_visible (GTK_WIDGET (self->more_results_btn), self->current_page == self->max_pages);
 
     // Make it clickable
     gtk_widget_set_sensitive (self->more_results_btn, TRUE);

--- a/src/exm-browse-page.c
+++ b/src/exm-browse-page.c
@@ -147,7 +147,7 @@ update_load_more_btn (ExmBrowsePage *self)
     gtk_widget_set_visible (GTK_WIDGET (self->more_results_btn), self->current_page == self->max_pages);
 
     // Make it clickable
-    gtk_widget_set_sensitive (self->more_results_btn, TRUE);
+    gtk_widget_set_sensitive (GTK_WIDGET (self->more_results_btn), TRUE);
 }
 
 static void
@@ -235,7 +235,7 @@ on_load_more_results (GtkButton     *btn,
 {
     const char *query;
     ExmSearchSort sort;
-    gtk_widget_set_sensitive (self->more_results_btn, FALSE);
+    gtk_widget_set_sensitive (GTK_WIDGET (self->more_results_btn), FALSE);
 
     query = gtk_editable_get_text (GTK_EDITABLE (self->search_entry));
     sort = (ExmSearchSort) gtk_drop_down_get_selected (self->search_dropdown);
@@ -279,7 +279,7 @@ on_search_entry_realize (GtkSearchEntry *search_entry,
     int num_suggestions;
 
     // Get random suggestion
-    num_suggestions = g_list_model_get_n_items (self->suggestions);
+    num_suggestions = g_list_model_get_n_items (G_LIST_MODEL (self->suggestions));
     random_index = g_random_int_range (0, num_suggestions);
     suggestion = gtk_string_list_get_string (self->suggestions, random_index);
 

--- a/src/exm-detail-view.c
+++ b/src/exm-detail-view.c
@@ -430,18 +430,18 @@ open_link (ExmDetailView *self,
            GVariant      *param)
 {
     GtkWidget *toplevel;
-    gchar *uri = NULL;
+    GtkUriLauncher *uri = NULL;
 
     toplevel = GTK_WIDGET (gtk_widget_get_root (GTK_WIDGET (self)));
 
     if (strcmp (action_name, "detail.open-extensions") == 0)
-        uri = self->uri_extensions;
+        uri = gtk_uri_launcher_new (self->uri_extensions);
     else if (strcmp (action_name, "detail.open-homepage") == 0)
         g_warning ("open_link(): cannot open homepage as not yet implemented.");
     else
         g_critical ("open_link() invalid action: %s", action_name);
 
-    gtk_show_uri (GTK_WINDOW (toplevel), uri, GDK_CURRENT_TIME);
+    gtk_uri_launcher_launch (uri, GTK_WINDOW (toplevel), NULL, NULL, NULL);
 }
 
 static void

--- a/src/exm-detail-view.c
+++ b/src/exm-detail-view.c
@@ -405,7 +405,7 @@ exm_detail_view_load_for_uuid (ExmDetailView *self,
     adw_window_title_set_subtitle (self->title, NULL);
 
     gtk_stack_set_visible_child_name (self->stack, "page_spinner");
-	gtk_widget_hide (GTK_WIDGET (self->image_overlay));
+    gtk_widget_set_visible (GTK_WIDGET (self->image_overlay), FALSE);
 
     exm_data_provider_get_async (self->provider, uuid, NULL, on_data_loaded, self);
 }
@@ -543,6 +543,16 @@ exm_detail_view_class_init (ExmDetailViewClass *klass)
 }
 
 static void
+widget_show(GtkWidget *widget) {
+    gtk_widget_set_visible(widget, TRUE);
+}
+
+static void
+widget_hide(GtkWidget *widget) {
+    gtk_widget_set_visible(widget, FALSE);
+}
+
+static void
 exm_detail_view_init (ExmDetailView *self)
 {
     GSimpleActionGroup *group;
@@ -577,11 +587,11 @@ exm_detail_view_init (ExmDetailView *self)
 
 	g_signal_connect_swapped (self->ext_screenshot_popout_button,
 							  "clicked",
-							  G_CALLBACK (gtk_widget_show),
+							  G_CALLBACK (widget_show),
 							  self->image_overlay);
 
 	g_signal_connect_swapped (self->ext_screenshot_popin_button,
 							  "clicked",
-							  G_CALLBACK (gtk_widget_hide),
+							  G_CALLBACK (widget_hide),
 							  self->image_overlay);
 }

--- a/src/exm-error-dialog.c
+++ b/src/exm-error-dialog.c
@@ -134,7 +134,9 @@ on_copy_button_clicked (GtkWidget      *button,
 static void
 on_new_issue_button_clicked (ExmErrorDialog *window)
 {
-    gtk_show_uri (GTK_WINDOW (window), "https://github.com/mjakeman/extension-manager/issues", GDK_CURRENT_TIME);
+    GtkUriLauncher *uri = gtk_uri_launcher_new ("https://github.com/mjakeman/extension-manager/issues");
+
+    gtk_uri_launcher_launch (uri, GTK_WINDOW (window), NULL, NULL, NULL);
 }
 
 static void

--- a/src/exm-error-dialog.c
+++ b/src/exm-error-dialog.c
@@ -114,7 +114,7 @@ exm_error_dialog_set_property (GObject      *object,
 }
 
 static void
-on_copy_button_clicked (GtkWidget      *button,
+on_copy_button_clicked (GtkButton      *button,
                         ExmErrorDialog *window)
 {
     GdkDisplay *display;

--- a/src/exm-extension-row.blp
+++ b/src/exm-extension-row.blp
@@ -2,6 +2,8 @@ using Gtk 4.0;
 using Adw 1;
 
 template $ExmExtensionRow : Adw.ExpanderRow {
+	title-lines: 1;
+	subtitle-lines: 1;
 
 	[action]
 	Gtk.Switch ext_toggle {

--- a/src/exm-extension-row.c
+++ b/src/exm-extension-row.c
@@ -378,16 +378,4 @@ exm_extension_row_init (ExmExtensionRow *self)
     g_action_map_add_action (G_ACTION_MAP (self->action_group), G_ACTION (remove_action));
 
     gtk_widget_insert_action_group (GTK_WIDGET (self), "row", G_ACTION_GROUP (self->action_group));
-
-    // Hack until libadwaita 1.3
-    // See: https://gitlab.gnome.org/GNOME/libadwaita/-/merge_requests/673
-    action_row = gtk_widget_get_first_child (self);
-    action_row = gtk_widget_get_first_child (action_row);
-    action_row = gtk_widget_get_first_child (action_row);
-
-    if (ADW_IS_ACTION_ROW (action_row))
-    {
-        adw_action_row_set_title_lines (ADW_ACTION_ROW (action_row), 1);
-        adw_action_row_set_subtitle_lines (ADW_ACTION_ROW (action_row), 1);
-    }
 }

--- a/src/exm-installed-page.c
+++ b/src/exm-installed-page.c
@@ -332,10 +332,11 @@ exm_installed_page_class_init (ExmInstalledPageClass *klass)
 static GtkWidget *
 create_user_placeholder ()
 {
-    GtkWidget *row, *button;
+    GtkWidget *row, *button, *icon;
 
     row = adw_action_row_new ();
     button = gtk_button_new_with_label (_("Browse"));
+    icon = gtk_image_new_from_icon_name ("globe-symbolic");
 
     gtk_widget_set_valign (button, GTK_ALIGN_CENTER);
     gtk_widget_set_halign (button, GTK_ALIGN_CENTER);
@@ -343,7 +344,7 @@ create_user_placeholder ()
     gtk_actionable_set_action_name (GTK_ACTIONABLE (button), "win.show-page");
     gtk_actionable_set_action_target (GTK_ACTIONABLE (button), "s", "browse");
 
-    adw_action_row_set_icon_name (ADW_ACTION_ROW (row), "globe-symbolic");
+    adw_action_row_add_prefix (ADW_ACTION_ROW (row), icon);
     adw_preferences_row_set_title (ADW_PREFERENCES_ROW (row),
                                    _("There are no user extensions installed."));
     adw_action_row_add_suffix (ADW_ACTION_ROW (row), button);
@@ -354,10 +355,11 @@ create_user_placeholder ()
 static GtkWidget *
 create_system_placeholder ()
 {
-    GtkWidget *row;
+    GtkWidget *row, *icon;
 
     row = adw_action_row_new ();
-    adw_action_row_set_icon_name (ADW_ACTION_ROW (row), "settings-symbolic");
+    icon = gtk_image_new_from_icon_name ("settings-symbolic");
+    adw_action_row_add_prefix (ADW_ACTION_ROW (row), icon);
     adw_preferences_row_set_title (ADW_PREFERENCES_ROW (row),
                                    _("There are no system extensions installed."));
 

--- a/src/exm-upgrade-assistant.c
+++ b/src/exm-upgrade-assistant.c
@@ -656,7 +656,7 @@ exm_upgrade_assistant_class_init (ExmUpgradeAssistantClass *klass)
 static void
 exm_upgrade_assistant_init (ExmUpgradeAssistant *self)
 {
-    GtkWidget *placeholder;
+    GtkWidget *placeholder, *icon;
 
     gtk_widget_init_template (GTK_WIDGET (self));
 
@@ -684,12 +684,14 @@ exm_upgrade_assistant_init (ExmUpgradeAssistant *self)
     bind_list_box (self, self->system_list_box, G_LIST_MODEL (self->system_results_store));
 
     placeholder = adw_action_row_new ();
-    adw_action_row_set_icon_name (ADW_ACTION_ROW (placeholder), "puzzle-piece-symbolic");
+    icon = gtk_image_new_from_icon_name ("puzzle-piece-symbolic");
+    adw_action_row_add_prefix (ADW_ACTION_ROW (placeholder), icon);
     adw_preferences_row_set_title (ADW_PREFERENCES_ROW (placeholder), _("There are no user extensions installed."));
     gtk_list_box_set_placeholder (self->user_list_box, placeholder);
 
     placeholder = adw_action_row_new ();
-    adw_action_row_set_icon_name (ADW_ACTION_ROW (placeholder), "settings-symbolic");
+    icon = gtk_image_new_from_icon_name ("settings-symbolic");
+    adw_action_row_add_prefix (ADW_ACTION_ROW (placeholder), icon);
     adw_preferences_row_set_title (ADW_PREFERENCES_ROW (placeholder), _("There are no system extensions installed."));
     gtk_list_box_set_placeholder (self->system_list_box, placeholder);
 

--- a/src/exm-window.c
+++ b/src/exm-window.c
@@ -187,7 +187,7 @@ extension_remove (GtkWidget  *widget,
     data->extension = g_object_ref (extension);
 
     g_signal_connect (dlg, "response", G_CALLBACK (extension_remove_dialog_response), data);
-    gtk_widget_show (dlg);
+    gtk_window_present (GTK_WINDOW (dlg));
 }
 
 static void
@@ -254,7 +254,7 @@ extension_install (GtkWidget  *widget,
         data->uuid = g_strdup (uuid);
 
         g_signal_connect (dlg, "response", G_CALLBACK (extension_unsupported_dialog_response), data);
-        gtk_widget_show (dlg);
+        gtk_window_present (GTK_WINDOW (dlg));
 
         return;
     }

--- a/src/exm-window.c
+++ b/src/exm-window.c
@@ -381,7 +381,7 @@ on_error (ExmManager *manager,
           char       *error_text,
           ExmWindow  *self)
 {
-    gtk_widget_activate_action (self, "win.show-error", "s", error_text);
+    gtk_widget_activate_action (GTK_WIDGET (self), "win.show-error", "s", error_text);
 }
 
 static void

--- a/src/exm-window.c
+++ b/src/exm-window.c
@@ -145,12 +145,12 @@ typedef struct
 
 static void
 extension_remove_dialog_response (GtkDialog        *dialog,
-                                  int               response_id,
+                                  const char       *response,
                                   RemoveDialogData *data)
 {
     gtk_window_destroy (GTK_WINDOW (dialog));
 
-    if (response_id == GTK_RESPONSE_YES)
+    if (strcmp(response, "yes") == 0)
     {
         exm_manager_remove_extension (data->manager, data->extension);
     }
@@ -176,11 +176,19 @@ extension_remove (GtkWidget  *widget,
 
     GtkWidget *dlg;
 
-    dlg = gtk_message_dialog_new (GTK_WINDOW (self),
-                                  GTK_DIALOG_MODAL,
-                                  GTK_MESSAGE_QUESTION,
-                                  GTK_BUTTONS_YES_NO,
-                                  _("Are you sure you want to uninstall?"));
+    dlg = adw_message_dialog_new (GTK_WINDOW (self),
+                                  _("Uninstall Extension?"),
+                                  _("The extension's features and functionality will no longer be accessible. Are you sure you want to uninstall?"));
+
+    adw_message_dialog_add_responses (ADW_MESSAGE_DIALOG (dlg),
+                                      "no", _("_No"),
+                                      "yes", _("_Yes"),
+                                      NULL);
+
+    adw_message_dialog_set_response_appearance (ADW_MESSAGE_DIALOG (dlg), "yes", ADW_RESPONSE_DESTRUCTIVE);
+
+    adw_message_dialog_set_default_response (ADW_MESSAGE_DIALOG (dlg), "no");
+    adw_message_dialog_set_close_response (ADW_MESSAGE_DIALOG (dlg), "no");
 
     RemoveDialogData *data = g_new0 (RemoveDialogData, 1);
     data->manager = g_object_ref (self->manager);
@@ -210,12 +218,12 @@ typedef struct
 
 static void
 extension_unsupported_dialog_response (GtkDialog             *dialog,
-                                       int                    response_id,
+                                       const char            *response,
                                        UnsupportedDialogData *data)
 {
     gtk_window_destroy (GTK_WINDOW (dialog));
 
-    if (response_id == GTK_RESPONSE_YES)
+    if (strcmp(response, "yes") == 0)
     {
         exm_manager_install_async (data->manager, data->uuid, NULL,
                                    (GAsyncReadyCallback) on_install_done,
@@ -243,11 +251,20 @@ extension_install (GtkWidget  *widget,
     {
         GtkWidget *dlg;
 
-        dlg = gtk_message_dialog_new (GTK_WINDOW (self),
-                                      GTK_DIALOG_MODAL,
-                                      GTK_MESSAGE_QUESTION,
-                                      GTK_BUTTONS_YES_NO,
-                                      _("This extension does not support your GNOME Shell version.\nWould you like to install anyway?"));
+        dlg = adw_message_dialog_new (GTK_WINDOW (self),
+                                      _("Unsupported Extension"),
+                                      _("This extension does not support your GNOME Shell version. It may cause errors if installed."));
+
+        adw_message_dialog_add_responses (ADW_MESSAGE_DIALOG (dlg),
+                                          "yes", _("_Install Anyway"),
+                                          "no", _("_Go Back"),
+                                          NULL);
+
+        adw_message_dialog_set_response_appearance (ADW_MESSAGE_DIALOG (dlg), "yes", ADW_RESPONSE_DESTRUCTIVE);
+        adw_message_dialog_set_response_appearance (ADW_MESSAGE_DIALOG (dlg), "no", ADW_RESPONSE_SUGGESTED);
+
+        adw_message_dialog_set_default_response (ADW_MESSAGE_DIALOG (dlg), "no");
+        adw_message_dialog_set_close_response (ADW_MESSAGE_DIALOG (dlg), "no");
 
         UnsupportedDialogData *data = g_new0 (UnsupportedDialogData, 1);
         data->manager = g_object_ref (self->manager);

--- a/src/exm-zoom-picture.c
+++ b/src/exm-zoom-picture.c
@@ -278,7 +278,7 @@ on_gesture_begin (GtkGesture       *gesture,
 				  GdkEventSequence *sequence,
 				  ExmZoomPicture   *self)
 {
-	gtk_gesture_set_sequence_state (gesture, sequence, GTK_EVENT_SEQUENCE_CLAIMED);
+	gtk_gesture_set_state (gesture, GTK_EVENT_SEQUENCE_CLAIMED);
 	self->gesture_start_zoom = self->zoom_level;
 	self->gesture_image_start_x = self->image_x;
 	self->gesture_image_start_y = self->image_y;


### PR DESCRIPTION
Wording could probably be improved.

|Uninstall extension dialog | Install unsupported extension dialog|
|---------------------|------------------------|
| ![image](https://github.com/mjakeman/extension-manager/assets/42654671/43522d2f-0c1b-49de-85ea-16acf700cbe3) | ![image](https://github.com/mjakeman/extension-manager/assets/42654671/18154c55-789e-40da-bc3c-fedab9570972) |
| ![image](https://github.com/mjakeman/extension-manager/assets/42654671/ab67047a-d1f9-464f-ab04-cfaabe865b63) | ![image](https://github.com/mjakeman/extension-manager/assets/42654671/cc6312ff-8592-49fc-a123-1ff18e0d5690) |