### PR TITLE
metainfo: Add supports and requires tags

### DIFF
--- a/data/com.mattjakeman.ExtensionManager.metainfo.xml.in.in
+++ b/data/com.mattjakeman.ExtensionManager.metainfo.xml.in.in
@@ -37,6 +37,14 @@
     <keyword>Shell</keyword>
   </keywords>
   <translation type="gettext">extension-manager</translation>
+  <supports>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>touch</control>
+  </supports>
+  <requires>
+    <display_length compare="ge">360</display_length>
+  </requires>
   <releases>
     <release version="0.4.2" date="2023-06-19">
       <description>


### PR DESCRIPTION
See https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html

These changes will not appear until flatpak-builder 1.4.x, which uses libappstream instead of appsteam-glib, is released and Flathub's buildbot rebuilds it with that version.

| master | PR |
|-|-|
| ![Captura desde 2023-08-20 00-01-20](https://github.com/mjakeman/extension-manager/assets/42654671/3efb6af3-bea3-4596-9a7a-b6d7e2209a84) | ![Captura desde 2023-08-20 00-05-36](https://github.com/mjakeman/extension-manager/assets/42654671/d388abdd-b584-4f9a-a35e-0d0aff26c053) |