### PR TITLE
search: Add relevance sort type

### DIFF
--- a/src/exm-browse-page.blp
+++ b/src/exm-browse-page.blp
@@ -28,7 +28,7 @@ template $ExmBrowsePage : Gtk.Widget {
 						Gtk.DropDown search_dropdown {
 							model: StringList {
 								// Translators: dropdown items for sorting search results
-								strings [_("Popularity"), _("Downloads"), _("Recent"), _("Name")]
+								strings [_("Relevance"), _("Popularity"), _("Downloads"), _("Recent"), _("Name")]
 							};
 						}
 					}

--- a/src/exm-browse-page.c
+++ b/src/exm-browse-page.c
@@ -295,7 +295,7 @@ on_search_entry_realize (GtkSearchEntry *search_entry,
     g_object_set (search_entry, "placeholder-text", fmt, NULL);
 
     // Fire off a default search
-    search (self, "", EXM_SEARCH_SORT_POPULARITY);
+    search (self, "", EXM_SEARCH_SORT_RELEVANCE);
     gtk_widget_grab_focus (GTK_WIDGET (search_entry));
 }
 

--- a/src/web/exm-search-provider.c
+++ b/src/web/exm-search-provider.c
@@ -160,8 +160,10 @@ get_sort_string (ExmSearchSort sort_type)
     case EXM_SEARCH_SORT_NAME:
         return "name";
     case EXM_SEARCH_SORT_POPULARITY:
-    default:
         return "popularity";
+    case EXM_SEARCH_SORT_RELEVANCE:
+    default:
+        return "relevance";
     }
 }
 

--- a/src/web/exm-search-provider.h
+++ b/src/web/exm-search-provider.h
@@ -13,10 +13,11 @@ G_DECLARE_FINAL_TYPE (ExmSearchProvider, exm_search_provider, EXM, SEARCH_PROVID
 
 typedef enum
 {
-    EXM_SEARCH_SORT_POPULARITY = 0,
-    EXM_SEARCH_SORT_DOWNLOADS = 1,
-    EXM_SEARCH_SORT_RECENT = 2,
-    EXM_SEARCH_SORT_NAME = 3
+    EXM_SEARCH_SORT_RELEVANCE = 0,
+    EXM_SEARCH_SORT_POPULARITY = 1,
+    EXM_SEARCH_SORT_DOWNLOADS = 2,
+    EXM_SEARCH_SORT_RECENT = 3,
+    EXM_SEARCH_SORT_NAME = 4
 } ExmSearchSort;
 
 ExmSearchProvider *exm_search_provider_new (void);


### PR DESCRIPTION
It is used by default for search in extensions web, the rest are somewhat broken.

Fix #478