### PR TITLE
flatpak: Add WebP support

### DIFF
--- a/com.mattjakeman.ExtensionManager.Devel.json
+++ b/com.mattjakeman.ExtensionManager.Devel.json
@@ -11,7 +11,8 @@
         "--device=dri",
         "--socket=wayland",
         "--talk-name=org.gnome.Shell.Extensions",
-        "--talk-name=org.gnome.SessionManager"
+        "--talk-name=org.gnome.SessionManager",
+        "--env=GDK_PIXBUF_MODULE_FILE=/app/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"
     ],
     "cleanup" : [
         "/include",
@@ -25,6 +26,28 @@
         "*.a"
     ],
     "modules" : [
+        {
+            "name" : "webp-pixbuf-loader",
+            "buildsystem" : "meson",
+            "config-opts" : [
+                "-Dgdk_pixbuf_moduledir=/app/lib/gdk-pixbuf-2.0/2.10.0/loaders/"
+            ],
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://github.com/aruiz/webp-pixbuf-loader.git",
+                    "tag" : "0.2.4"
+                }
+            ]
+        },
+        {
+            "name" : "update-pixbuf-loaders",
+            "buildsystem" : "simple",
+            "build-commands" : [
+                "GDK_PIXBUF_MODULEDIR=/app/lib/gdk-pixbuf-2.0/2.10.0/loaders/ gdk-pixbuf-query-loaders > /app/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache",
+                "gdk-pixbuf-query-loaders >> /app/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"
+            ]
+        },
     	{
             "name": "blueprint-compiler",
             "builddir": true,


### PR DESCRIPTION
GNOME Extensions web allows uploading [WebP images](https://gitlab.gnome.org/Infrastructure/extensions-web/-/blob/master/sweettooth/extensions/forms.py?ref_type=heads#L55). `webp-pixbuf-loader` is installed out of the box in distributions like Ubuntu or Fedora, but that is not the case for GNOME SDK as of [now](https://gitlab.gnome.org/GNOME/gnome-build-meta/-/issues/677).

Tested with an [extension](https://extensions.gnome.org/extension/5985/do-not-disturb-while-screen-sharing-or-recording/) that has its icon in that format:

![image](https://github.com/mjakeman/extension-manager/assets/42654671/535d8c40-2cea-41b6-b218-3bc4534e01a8)