### PR TITLE
detail-view: Add info bar

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -14,6 +14,8 @@ src/exm-error-dialog.blp
 src/exm-error-dialog.c
 src/exm-extension-row.blp
 src/exm-extension-row.c
+src/exm-info-bar.blp
+src/exm-info-bar.c
 src/exm-install-button.c
 src/exm-installed-page.blp
 src/exm-installed-page.c

--- a/src/exm-detail-view.blp
+++ b/src/exm-detail-view.blp
@@ -167,6 +167,8 @@ template $ExmDetailView : Adw.NavigationPage {
 									}
 								}
 
+								$ExmInfoBar ext_info_bar {}
+
 								Gtk.Box {
 									orientation: vertical;
 
@@ -205,22 +207,6 @@ template $ExmDetailView : Adw.NavigationPage {
 												icon-name: "external-link-symbolic";
 											}
 										}
-									}
-								}
-
-								Gtk.Box {
-									orientation: vertical;
-
-									Gtk.Label {
-										styles ["title-4", "detail-heading"]
-
-										label: _("Supported Versions");
-										xalign: 0;
-									}
-
-									Gtk.FlowBox supported_versions {
-										max-children-per-line: 100;
-										selection-mode: none;
 									}
 								}
 

--- a/src/exm-detail-view.h
+++ b/src/exm-detail-view.h
@@ -17,4 +17,7 @@ exm_detail_view_load_for_uuid (ExmDetailView *self,
 void
 exm_detail_view_update (ExmDetailView *self);
 
+void
+exm_detail_view_adaptive (ExmDetailView *self, AdwBreakpoint *breakpoint);
+
 G_END_DECLS

--- a/src/exm-info-bar-item.blp
+++ b/src/exm-info-bar-item.blp
@@ -1,0 +1,43 @@
+using Gtk 4.0;
+using Adw 1;
+
+template $ExmInfoBarItem: Adw.Bin {
+	styles [
+		"card"
+	]
+
+	focusable: true;
+	height-request: 54;
+
+	Gtk.Box {
+		orientation: horizontal;
+
+		Gtk.Image icon {
+			margin-start: 12;
+			margin-end: 12;
+		}
+
+		Gtk.Box {
+			orientation: vertical;
+			valign: center;
+
+			Gtk.Label title {
+				xalign: 0;
+			}
+
+			Gtk.Label subtitle {
+				styles [
+					"dim-label",
+					"numeric"
+				]
+
+				xalign: 0;
+			}
+		}
+	}
+
+	accessibility {
+		labelled-by: title;
+		described-by: subtitle;
+	}
+}

--- a/src/exm-info-bar-item.c
+++ b/src/exm-info-bar-item.c
@@ -1,0 +1,154 @@
+#include "exm-info-bar-item.h"
+
+struct _ExmInfoBarItem
+{
+    AdwBin parent_instance;
+
+    GtkImage *icon;
+    GtkLabel *title;
+    GtkLabel *subtitle;
+};
+
+G_DEFINE_FINAL_TYPE (ExmInfoBarItem, exm_info_bar_item, ADW_TYPE_BIN)
+
+enum {
+    PROP_0,
+    PROP_ICON,
+    PROP_TITLE,
+    PROP_SUBTITLE,
+    N_PROPS
+};
+
+static GParamSpec *properties [N_PROPS];
+
+ExmInfoBarItem *
+exm_info_bar_info_item_new (void)
+{
+    return g_object_new (EXM_TYPE_INFO_BAR_ITEM, NULL);
+}
+
+static void
+exm_info_bar_item_finalize (GObject *object)
+{
+    ExmInfoBarItem *self = (ExmInfoBarItem *)object;
+
+    G_OBJECT_CLASS (exm_info_bar_item_parent_class)->finalize (object);
+}
+
+GtkLabel *
+exm_info_bar_item_get_subtitle (ExmInfoBarItem *self)
+{
+    g_return_val_if_fail (EXM_IS_INFO_BAR_ITEM (self), NULL);
+
+    return self->subtitle;
+}
+
+void
+exm_info_bar_item_set_subtitle (ExmInfoBarItem *self,
+                                const char     *subtitle)
+{
+    g_return_if_fail (EXM_IS_INFO_BAR_ITEM (self));
+
+    if (g_strcmp0 (gtk_label_get_label (self->subtitle), subtitle) == 0)
+      return;
+
+    gtk_label_set_label (self->subtitle, subtitle);
+
+    g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_SUBTITLE]);
+}
+
+static void
+exm_info_bar_item_get_property (GObject    *object,
+                                guint       prop_id,
+                                GValue     *value,
+                                GParamSpec *pspec)
+{
+    ExmInfoBarItem *self = EXM_INFO_BAR_ITEM (object);
+
+    switch (prop_id)
+    {
+    case PROP_ICON:
+        g_value_set_string (value, gtk_image_get_icon_name (self->icon));
+        break;
+    case PROP_TITLE:
+        g_value_set_string (value, gtk_label_get_label (self->title));
+        break;
+    case PROP_SUBTITLE:
+        g_value_set_string (value, gtk_label_get_text (exm_info_bar_item_get_subtitle (self)));
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+exm_info_bar_item_set_property (GObject      *object,
+                                guint         prop_id,
+                                const GValue *value,
+                                GParamSpec   *pspec)
+{
+    ExmInfoBarItem *self = EXM_INFO_BAR_ITEM (object);
+
+    switch (prop_id)
+    {
+    case PROP_ICON:
+        gtk_image_set_from_icon_name (self->icon, g_value_get_string (value));
+        break;
+    case PROP_TITLE:
+        gtk_label_set_label (self->title, g_value_get_string (value));
+        break;
+    case PROP_SUBTITLE:
+        exm_info_bar_item_set_subtitle (self, g_value_get_string (value));
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+exm_info_bar_item_class_init (ExmInfoBarItemClass *klass)
+{
+    GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+    object_class->finalize = exm_info_bar_item_finalize;
+    object_class->get_property = exm_info_bar_item_get_property;
+    object_class->set_property = exm_info_bar_item_set_property;
+
+    properties [PROP_ICON] =
+        g_param_spec_string ("icon",
+                             "Icon",
+                             "The icon for the item",
+                             NULL,
+                             (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+    properties [PROP_TITLE] =
+        g_param_spec_string ("title",
+                             "Title",
+                             "The title for the item",
+                             NULL,
+                             (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+    properties [PROP_SUBTITLE] =
+        g_param_spec_string ("subtitle",
+                             "Subtitle",
+                             "The subtitle for the item",
+                             NULL,
+                             (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+    g_object_class_install_properties (object_class, N_PROPS, properties);
+
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+
+    gtk_widget_class_set_template_from_resource (widget_class, "/com/mattjakeman/ExtensionManager/exm-info-bar-item.ui");
+
+    g_type_ensure (EXM_TYPE_INFO_BAR_ITEM);
+
+    gtk_widget_class_bind_template_child (widget_class, ExmInfoBarItem, icon);
+    gtk_widget_class_bind_template_child (widget_class, ExmInfoBarItem, title);
+    gtk_widget_class_bind_template_child (widget_class, ExmInfoBarItem, subtitle);
+}
+
+static void
+exm_info_bar_item_init (ExmInfoBarItem *self)
+{
+    gtk_widget_init_template (GTK_WIDGET (self));
+}

--- a/src/exm-info-bar-item.h
+++ b/src/exm-info-bar-item.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <adwaita.h>
+
+G_BEGIN_DECLS
+
+#define EXM_TYPE_INFO_BAR_ITEM (exm_info_bar_item_get_type())
+
+G_DECLARE_FINAL_TYPE (ExmInfoBarItem, exm_info_bar_item, EXM, INFO_BAR_ITEM, AdwBin)
+
+ExmInfoBarItem *
+exm_info_bar_item_new (void);
+
+void
+exm_info_bar_item_set_subtitle (ExmInfoBarItem *info_bar_item, const char *subtitle);
+
+G_END_DECLS

--- a/src/exm-info-bar.blp
+++ b/src/exm-info-bar.blp
@@ -1,0 +1,21 @@
+using Gtk 4.0;
+
+template $ExmInfoBar: Gtk.Box {
+	styles [
+		"info-bar"
+	]
+
+	homogeneous: true;
+	orientation: horizontal;
+
+	$ExmInfoBarItem downloads_item {
+		icon: "folder-download-symbolic";
+		title: _("Downloads");
+	}
+
+	$ExmInfoBarItem version_item {
+		icon: "system-software-install-symbolic";
+		title: _("Version");
+		subtitle: _("Unsupported");
+	}
+}

--- a/src/exm-info-bar.c
+++ b/src/exm-info-bar.c
@@ -1,0 +1,107 @@
+#include "exm-info-bar.h"
+
+#include "exm-info-bar-item.h"
+
+#include <glib/gi18n.h>
+
+struct _ExmInfoBar
+{
+    GtkBox parent_instance;
+
+    ExmInfoBarItem *downloads_item;
+    ExmInfoBarItem *version_item;
+
+    guint signal_handler;
+};
+
+G_DEFINE_FINAL_TYPE (ExmInfoBar, exm_info_bar, GTK_TYPE_BOX)
+
+enum {
+    PROP_0,
+    N_PROPS
+};
+
+static GParamSpec *properties [N_PROPS];
+
+ExmInfoBar *
+exm_info_bar_new (void)
+{
+    return g_object_new (EXM_TYPE_INFO_BAR, NULL);
+}
+
+static void
+exm_info_bar_finalize (GObject *object)
+{
+    ExmInfoBar *self = (ExmInfoBar *)object;
+
+    G_OBJECT_CLASS (exm_info_bar_parent_class)->finalize (object);
+}
+
+static void
+exm_info_bar_get_property (GObject    *object,
+                           guint       prop_id,
+                           GValue     *value,
+                           GParamSpec *pspec)
+{
+    ExmInfoBar *self = EXM_INFO_BAR (object);
+
+    switch (prop_id)
+    {
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+exm_info_bar_set_property (GObject      *object,
+                           guint         prop_id,
+                           const GValue *value,
+                           GParamSpec   *pspec)
+{
+    ExmInfoBar *self = EXM_INFO_BAR (object);
+
+    switch (prop_id)
+    {
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+void
+exm_info_bar_set_downloads (ExmInfoBar   *self,
+                            guint         downloads)
+{
+    exm_info_bar_item_set_subtitle (self->downloads_item, g_strdup_printf ("%'d", downloads));
+}
+
+void
+exm_info_bar_set_version (ExmInfoBar   *self,
+                          double        version)
+{
+    exm_info_bar_item_set_subtitle (self->version_item, version == -1 ? _("Unsupported") : g_strdup_printf("%.f", version));
+}
+
+static void
+exm_info_bar_class_init (ExmInfoBarClass *klass)
+{
+    GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+    object_class->finalize = exm_info_bar_finalize;
+    object_class->get_property = exm_info_bar_get_property;
+    object_class->set_property = exm_info_bar_set_property;
+
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+
+    gtk_widget_class_set_template_from_resource (widget_class, "/com/mattjakeman/ExtensionManager/exm-info-bar.ui");
+
+    g_type_ensure (EXM_TYPE_INFO_BAR);
+
+    gtk_widget_class_bind_template_child (widget_class, ExmInfoBar, downloads_item);
+    gtk_widget_class_bind_template_child (widget_class, ExmInfoBar, version_item);
+}
+
+static void
+exm_info_bar_init (ExmInfoBar *self)
+{
+    gtk_widget_init_template (GTK_WIDGET (self));
+}

--- a/src/exm-info-bar.h
+++ b/src/exm-info-bar.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <gtk/gtk.h>
+
+G_BEGIN_DECLS
+
+#define EXM_TYPE_INFO_BAR (exm_info_bar_get_type())
+
+G_DECLARE_FINAL_TYPE (ExmInfoBar, exm_info_bar, EXM, INFO_BAR, GtkBox)
+
+ExmInfoBar *
+exm_info_bar_new (void);
+
+void
+exm_info_bar_set_downloads (ExmInfoBar *info_bar, guint downloads);
+
+void
+exm_info_bar_set_version (ExmInfoBar *info_bar, double version);
+
+G_END_DECLS

--- a/src/exm-window.blp
+++ b/src/exm-window.blp
@@ -7,7 +7,7 @@ template $ExmWindow : Adw.ApplicationWindow {
   width-request: 360;
   height-request: 294;
 
-  Adw.Breakpoint {
+  Adw.Breakpoint main_breakpoint {
     condition ("max-width: 400sp")
     setters {
       header_bar.title-widget: null;

--- a/src/exm-window.c
+++ b/src/exm-window.c
@@ -37,6 +37,7 @@ struct _ExmWindow
     ExmManager *manager;
 
     /* Template widgets */
+    AdwBreakpoint        *main_breakpoint;
     AdwHeaderBar         *header_bar;
     ExmBrowsePage        *browse_page;
     ExmInstalledPage     *installed_page;
@@ -315,6 +316,8 @@ show_view (GtkWidget  *widget,
 
         exm_detail_view_load_for_uuid (self->detail_view, uuid);
 
+        exm_detail_view_adaptive (self->detail_view, self->main_breakpoint);
+
         return;
     }
 
@@ -406,6 +409,7 @@ exm_window_class_init (ExmWindowClass *klass)
     GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
 
     gtk_widget_class_set_template_from_resource (widget_class, "/com/mattjakeman/ExtensionManager/exm-window.ui");
+    gtk_widget_class_bind_template_child (widget_class, ExmWindow, main_breakpoint);
     gtk_widget_class_bind_template_child (widget_class, ExmWindow, header_bar);
     gtk_widget_class_bind_template_child (widget_class, ExmWindow, installed_page);
     gtk_widget_class_bind_template_child (widget_class, ExmWindow, browse_page);

--- a/src/exm.gresource.xml.in
+++ b/src/exm.gresource.xml.in
@@ -13,6 +13,8 @@
     <file>exm-rating.ui</file>
     <file>exm-upgrade-assistant.ui</file>
     <file>exm-error-dialog.ui</file>
+    <file>exm-info-bar.ui</file>
+    <file>exm-info-bar-item.ui</file>
     <file alias="suggestions.txt">res/suggestions.txt</file>
     <file preprocess="xml-stripblanks" alias="com.mattjakeman.ExtensionManager.metainfo.xml">../data/@appstream_file@</file>
     <file>style.css</file>

--- a/src/meson.build
+++ b/src/meson.build
@@ -10,6 +10,8 @@ exm_sources = [
   'exm-comment-tile.c',
   'exm-comment-dialog.c',
   'exm-rating.c',
+  'exm-info-bar.c',
+  'exm-info-bar-item.c',
 
   # Installed Page
   'exm-installed-page.c',
@@ -62,7 +64,9 @@ blueprints = custom_target('blueprints',
     'exm-comment-dialog.blp',
     'exm-rating.blp',
     'exm-upgrade-assistant.blp',
-    'exm-error-dialog.blp'
+    'exm-error-dialog.blp',
+    'exm-info-bar.blp',
+    'exm-info-bar-item.blp'
   ),
   output: '.',
   command: [find_program('blueprint-compiler'), 'batch-compile', '@OUTPUT@', '@CURRENT_SOURCE_DIR@', '@INPUT@'],

--- a/src/style.css
+++ b/src/style.css
@@ -22,14 +22,6 @@
   padding: 10px 5px;
 }
 
-.version-label {
-  background-color: #62a0ea;
-  color: white;
-  border-radius: 4px;
-  padding: 4px;
-  box-shadow: 0 0 2px rgba(0,0,0,0.2);
-}
-
 .update {
   color: #ff7800;
 }
@@ -54,6 +46,28 @@ rating {
 
 .upgrade-assistant-result {
   padding: 12px;
+}
+
+.info-bar.horizontal > :not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  margin-left: 1px;
+}
+
+.info-bar.horizontal > :not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.info-bar.vertical > :not(:first-child) {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  margin-top: 1px;
+}
+
+.info-bar.vertical > :not(:last-child) {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
 /* Progress Bar Colours */

--- a/src/web/model/exm-search-result.c
+++ b/src/web/model/exm-search-result.c
@@ -17,6 +17,7 @@ struct _ExmSearchResult
     gchar *link;
     gchar *description;
     int pk;
+    int downloads;
     ExmShellVersionMap *shell_version_map;
 };
 
@@ -37,6 +38,7 @@ enum {
     PROP_LINK,
     PROP_DESCRIPTION,
     PROP_PK,
+    PROP_DOWNLOADS,
     PROP_SHELL_VERSION_MAP,
     N_PROPS
 };
@@ -96,6 +98,9 @@ exm_search_result_get_property (GObject    *object,
     case PROP_PK:
         g_value_set_int (value, self->pk);
         break;
+    case PROP_DOWNLOADS:
+        g_value_set_int (value, self->downloads);
+        break;
     case PROP_SHELL_VERSION_MAP:
         g_value_set_boxed (value, self->shell_version_map);
         break;
@@ -142,6 +147,9 @@ exm_search_result_set_property (GObject      *object,
         break;
     case PROP_PK:
         self->pk = g_value_get_int (value);
+        break;
+    case PROP_DOWNLOADS:
+        self->downloads = g_value_get_int (value);
         break;
     case PROP_SHELL_VERSION_MAP:
         if (self->shell_version_map)
@@ -267,6 +275,13 @@ exm_search_result_class_init (ExmSearchResultClass *klass)
         g_param_spec_int ("pk",
                           "Package ID",
                           "Package ID",
+                          0, G_MAXINT, 0,
+                          G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY);
+
+    properties [PROP_DOWNLOADS] =
+        g_param_spec_int ("downloads",
+                          "Downloads",
+                          "Downloads",
                           0, G_MAXINT, 0,
                           G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY);
 


### PR DESCRIPTION
TODO:
- [x] Show latest version available for the installed GNOME Shell version
- [x] Drop supported versions (?)
- [x] Make it focusable for keyboard navigation and screen readers
- [x] Review implementation again

![image](https://github.com/mjakeman/extension-manager/assets/42654671/95604b39-158b-41ef-95e7-60d3d169f04a)