### PR TITLE
detail-view: Add extension icon

### DIFF
--- a/src/exm-detail-view.blp
+++ b/src/exm-detail-view.blp
@@ -105,9 +105,16 @@ template $ExmDetailView : Adw.NavigationPage {
 									orientation: horizontal;
 									spacing: 25;
 
+									Gtk.Image ext_icon {
+										halign: center;
+										valign: center;
+										pixel-size: 64;
+									}
+
 									Gtk.Box {
 										orientation: vertical;
 										hexpand: true;
+										valign: center;
 
 										Gtk.Label ext_title {
 											styles ["title-1"]


### PR DESCRIPTION
If the extension has one.

For now it is mostly a duplication of the code that manages screenshots.

![image](https://github.com/mjakeman/extension-manager/assets/42654671/a226e9c6-d6e5-4399-8e42-2b6ee133fd62)