### PR TITLE
detail-view: Add extension's homepage

### DIFF
--- a/src/exm-detail-view.blp
+++ b/src/exm-detail-view.blp
@@ -167,19 +167,43 @@ template $ExmDetailView : Adw.NavigationPage {
 									}
 								}
 
-								Gtk.ListBox {
-									styles ["boxed-list"]
+								Gtk.Box {
+									orientation: vertical;
 
-									selection-mode: none;
+									Gtk.Label {
+										styles ["title-4", "detail-heading"]
 
-									Adw.ActionRow link_extensions {
-										title: _("View on Extensions");
-										activatable: true;
-										action-name: "detail.open-extensions";
+										label: _("Links");
+										xalign: 0;
+									}
 
-										Gtk.Image {
-											styles ["dim-label"]
-											icon-name: "external-link-symbolic";
+									Gtk.ListBox {
+										styles ["boxed-list"]
+
+										selection-mode: none;
+
+										Adw.ActionRow link_homepage {
+											icon-name: "go-home-symbolic";
+											title: _("Homepage");
+											activatable: true;
+											action-name: "detail.open-homepage";
+
+											Gtk.Image {
+												styles ["dim-label"]
+												icon-name: "external-link-symbolic";
+											}
+										}
+
+										Adw.ActionRow link_extensions {
+											icon-name: "web-browser-symbolic";
+											title: _("View on Extensions");
+											activatable: true;
+											action-name: "detail.open-extensions";
+
+											Gtk.Image {
+												styles ["dim-label"]
+												icon-name: "external-link-symbolic";
+											}
 										}
 									}
 								}

--- a/src/exm-detail-view.c
+++ b/src/exm-detail-view.c
@@ -71,6 +71,8 @@ struct _ExmDetailView
 	AdwBin *image_overlay;
 	ExmZoomPicture *overlay_screenshot;
 
+    AdwActionRow *link_homepage;
+    gchar *uri_homepage;
     AdwActionRow *link_extensions;
     gchar *uri_extensions;
     int pk;
@@ -286,7 +288,7 @@ on_data_loaded (GObject      *source,
     {
         gint pk;
         gboolean is_installed, is_supported;
-        gchar *uuid, *name, *creator, *icon_uri, *screenshot_uri, *link, *description;
+        gchar *uuid, *name, *creator, *icon_uri, *screenshot_uri, *link, *description, *url;
         g_object_get (data,
                       "uuid", &uuid,
                       "name", &name,
@@ -297,6 +299,7 @@ on_data_loaded (GObject      *source,
                       "description", &description,
                       "shell_version_map", &version_map,
                       "pk", &pk,
+                      "url", &url,
                       NULL);
 
         adw_window_title_set_title (self->title, name);
@@ -341,11 +344,17 @@ on_data_loaded (GObject      *source,
 
         g_object_set (self->ext_install, "state", install_state, NULL);
 
+        self->uri_homepage = g_uri_resolve_relative (url,
+                                                     "",
+                                                     G_URI_FLAGS_NONE,
+                                                     NULL);
+
         self->uri_extensions = g_uri_resolve_relative ("https://extensions.gnome.org/",
                                                        link,
                                                        G_URI_FLAGS_NONE,
                                                        NULL);
 
+        adw_action_row_set_subtitle (self->link_homepage, self->uri_homepage);
         adw_action_row_set_subtitle (self->link_extensions, self->uri_extensions);
 
         // Clear Flowbox
@@ -444,7 +453,7 @@ open_link (ExmDetailView *self,
     if (strcmp (action_name, "detail.open-extensions") == 0)
         uri = gtk_uri_launcher_new (self->uri_extensions);
     else if (strcmp (action_name, "detail.open-homepage") == 0)
-        g_warning ("open_link(): cannot open homepage as not yet implemented.");
+        uri = gtk_uri_launcher_new (self->uri_homepage);
     else
         g_critical ("open_link() invalid action: %s", action_name);
 
@@ -537,6 +546,7 @@ exm_detail_view_class_init (ExmDetailViewClass *klass)
 	gtk_widget_class_bind_template_child (widget_class, ExmDetailView, ext_screenshot_popout_button);
 	gtk_widget_class_bind_template_child (widget_class, ExmDetailView, ext_screenshot_popin_button);
     gtk_widget_class_bind_template_child (widget_class, ExmDetailView, supported_versions);
+    gtk_widget_class_bind_template_child (widget_class, ExmDetailView, link_homepage);
     gtk_widget_class_bind_template_child (widget_class, ExmDetailView, link_extensions);
     gtk_widget_class_bind_template_child (widget_class, ExmDetailView, scroll_area);
     gtk_widget_class_bind_template_child (widget_class, ExmDetailView, comment_box);

--- a/src/web/model/exm-search-result.c
+++ b/src/web/model/exm-search-result.c
@@ -13,6 +13,7 @@ struct _ExmSearchResult
     gchar *creator;
     gchar *icon;
     gchar *screenshot;
+    gchar *url;
     gchar *link;
     gchar *description;
     int pk;
@@ -32,6 +33,7 @@ enum {
     PROP_CREATOR,
     PROP_ICON,
     PROP_SCREENSHOT,
+    PROP_URL,
     PROP_LINK,
     PROP_DESCRIPTION,
     PROP_PK,
@@ -82,6 +84,9 @@ exm_search_result_get_property (GObject    *object,
     case PROP_SCREENSHOT:
         g_value_set_string (value, self->screenshot);
         break;
+    case PROP_URL:
+        g_value_set_string (value, self->url);
+        break;
     case PROP_LINK:
         g_value_set_string (value, self->link);
         break;
@@ -125,6 +130,9 @@ exm_search_result_set_property (GObject      *object,
         break;
     case PROP_SCREENSHOT:
         self->screenshot = g_value_dup_string (value);
+        break;
+    case PROP_URL:
+        self->url = g_value_dup_string (value);
         break;
     case PROP_LINK:
         self->link = g_value_dup_string (value);
@@ -231,6 +239,13 @@ exm_search_result_class_init (ExmSearchResultClass *klass)
         g_param_spec_string ("screenshot",
                              "Screenshot",
                              "Screenshot",
+                             NULL,
+                             G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY);
+
+    properties [PROP_URL] =
+        g_param_spec_string ("url",
+                             "Url",
+                             "Url",
                              NULL,
                              G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY);
 


### PR DESCRIPTION
See https://gitlab.gnome.org/Infrastructure/extensions-web/-/commit/6090340c180c8662283eecbe5642297261698fe6

Fix #162

![image](https://github.com/mjakeman/extension-manager/assets/42654671/155eda54-bce9-4d0b-a804-ab49c998bf76)