### PR TITLE
CI: Bumped Checkout (v4) & Flatpak Builder (v6.3)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,8 +11,8 @@ jobs:
       image: bilelmoussaoui/flatpak-github-actions:gnome-nightly
       options: --privileged
     steps:
-    - uses: actions/checkout@v3
-    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v6.1
+    - uses: actions/checkout@v4
+    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v6.3
       with:
         bundle: extension-manager.flatpak
         manifest-path: com.mattjakeman.ExtensionManager.Devel.json


### PR DESCRIPTION
### Details

- Bump `actions/checkout` from `v3` to `v4` the changes can be found [here](https://github.com/actions/checkout/compare/v3...v4), this includes **Node 20**
-  Bump `bilelmoussaoui/flatpak-github-actions/flatpak-builder` to `v6.3` from `v6.1`, just so everything is great :+1: 
