### PR TITLE
flatpak: Update manifest

### DIFF
--- a/com.mattjakeman.ExtensionManager.Devel.json
+++ b/com.mattjakeman.ExtensionManager.Devel.json
@@ -52,6 +52,9 @@
             "name": "blueprint-compiler",
             "builddir": true,
             "buildsystem": "meson",
+            "cleanup": [
+                "*"
+            ],
             "sources": [
                 {
                     "type": "git",

--- a/com.mattjakeman.ExtensionManager.Devel.json
+++ b/com.mattjakeman.ExtensionManager.Devel.json
@@ -1,5 +1,5 @@
 {
-    "app-id" : "com.mattjakeman.ExtensionManager.Devel",
+    "id" : "com.mattjakeman.ExtensionManager.Devel",
     "runtime" : "org.gnome.Platform",
     "runtime-version" : "45",
     "sdk" : "org.gnome.Sdk",


### PR DESCRIPTION
The change from `app-id` to `id` is something I have seen in some applications such as [GNOME Calendar](https://github.com/flathub/org.gnome.Calendar/commit/d5077fc54f6d7a76b28e352cdd9bf6203fdf739b).

The second commit is [directly copied](https://github.com/flathub/com.mattjakeman.ExtensionManager/pull/15/commits/544b83af7f09685a951b30a15519567fe839f55b) from the manifest changes in the Flathub repository, although it was reverted in the last update.

Also, the Flathub manifest is missing some config options, such as the distributor and the package type, which are present here.