### PR TITLE
Move from deprecated row icons to prefix and suffix

### DIFF
--- a/src/exm-detail-view.blp
+++ b/src/exm-detail-view.blp
@@ -185,7 +185,11 @@ template $ExmDetailView : Adw.NavigationPage {
 										selection-mode: none;
 
 										Adw.ActionRow link_homepage {
-											icon-name: "go-home-symbolic";
+											[prefix]
+											Gtk.Image {
+												icon-name: "go-home-symbolic";
+											}
+
 											title: _("Homepage");
 											activatable: true;
 											action-name: "detail.open-homepage";
@@ -197,7 +201,11 @@ template $ExmDetailView : Adw.NavigationPage {
 										}
 
 										Adw.ActionRow link_extensions {
-											icon-name: "web-browser-symbolic";
+											[prefix]
+											Gtk.Image {
+												icon-name: "web-browser-symbolic";
+											}
+
 											title: _("View on Extensions");
 											activatable: true;
 											action-name: "detail.open-extensions";

--- a/src/exm-detail-view.blp
+++ b/src/exm-detail-view.blp
@@ -194,6 +194,7 @@ template $ExmDetailView : Adw.NavigationPage {
 											activatable: true;
 											action-name: "detail.open-homepage";
 
+											[suffix]
 											Gtk.Image {
 												styles ["dim-label"]
 												icon-name: "external-link-symbolic";
@@ -210,6 +211,7 @@ template $ExmDetailView : Adw.NavigationPage {
 											activatable: true;
 											action-name: "detail.open-extensions";
 
+											[suffix]
 											Gtk.Image {
 												styles ["dim-label"]
 												icon-name: "external-link-symbolic";

--- a/src/exm-installed-page.blp
+++ b/src/exm-installed-page.blp
@@ -23,7 +23,11 @@ template $ExmInstalledPage : Gtk.Widget {
 							selection-mode: none;
 
 							Adw.SwitchRow global_toggle {
-								icon-name: 'puzzle-piece-symbolic';
+								[prefix]
+								Gtk.Image {
+									icon-name: 'puzzle-piece-symbolic';
+								}
+
 								title: _("Use Extensions");
 								subtitle: _("Extensions can cause performance and stability issues.");
 							}


### PR DESCRIPTION
Missed in #458

See https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/property.ActionRow.icon-name.html