### PR TITLE
comment-tile: Add extension's author badge

### DIFF
--- a/src/exm-comment-tile.blp
+++ b/src/exm-comment-tile.blp
@@ -13,11 +13,17 @@ template $ExmCommentTile : Gtk.Widget {
       Gtk.Label author {
         styles ["dim-label"]
         xalign: 0;
-        hexpand: true;
+      }
+
+      Gtk.Label author_badge {
+      	styles ["author-badge"]
+      	label: _("Author");
+      	visible: false;
       }
 
       $ExmRating rating {
         halign: end;
+        hexpand: true;
       }
     }
 

--- a/src/exm-comment-tile.c
+++ b/src/exm-comment-tile.c
@@ -12,6 +12,7 @@ struct _ExmCommentTile
     ExmComment *comment;
 
     GtkLabel *author;
+    GtkLabel *author_badge;
     ExmRating *rating;
     TextDisplay *display;
 };
@@ -87,9 +88,11 @@ exm_comment_tile_constructed (GObject *object)
 
     TextFrame *frame;
 
+    gboolean is_extension_creator;
     gchar *text, *author;
     int score;
     g_object_get (self->comment,
+                  "is_extension_creator", &is_extension_creator,
                   "comment", &text,
                   "author", &author,
                   "rating", &score,
@@ -109,6 +112,7 @@ exm_comment_tile_constructed (GObject *object)
 
     g_object_set (self->display, "frame", frame, NULL);
     gtk_label_set_text (self->author, author);
+    gtk_widget_set_visible (GTK_WIDGET (self->author_badge), is_extension_creator);
 
     G_OBJECT_CLASS (exm_comment_tile_parent_class)->constructed (object);
 }
@@ -138,6 +142,7 @@ exm_comment_tile_class_init (ExmCommentTileClass *klass)
 
     gtk_widget_class_bind_template_child (widget_class, ExmCommentTile, display);
     gtk_widget_class_bind_template_child (widget_class, ExmCommentTile, author);
+    gtk_widget_class_bind_template_child (widget_class, ExmCommentTile, author_badge);
     gtk_widget_class_bind_template_child (widget_class, ExmCommentTile, rating);
 
     gtk_widget_class_set_layout_manager_type (widget_class, GTK_TYPE_BIN_LAYOUT);

--- a/src/style.css
+++ b/src/style.css
@@ -70,6 +70,14 @@ rating {
   border-bottom-right-radius: 0;
 }
 
+.author-badge {
+	background-color: @blue_3;
+	border-radius: 999px;
+	color: @white_1;
+	margin-left: 6px;
+	padding: 2px 6px;
+}
+
 /* Progress Bar Colours */
 progressbar.error progress {
     background-color: @red_1;

--- a/src/web/model/exm-comment.c
+++ b/src/web/model/exm-comment.c
@@ -6,6 +6,7 @@ struct _ExmComment
 {
     GObject parent_instance;
 
+    gboolean is_extension_creator;
     gchar *comment;
     gchar *author;
     int rating;
@@ -21,6 +22,7 @@ G_DEFINE_FINAL_TYPE_WITH_CODE (ExmComment, exm_comment, G_TYPE_OBJECT,
 
 enum {
     PROP_0,
+    PROP_IS_EXTENSION_CREATOR,
     PROP_COMMENT,
     PROP_AUTHOR,
     PROP_RATING,
@@ -53,6 +55,9 @@ exm_comment_get_property (GObject    *object,
 
     switch (prop_id)
     {
+    case PROP_IS_EXTENSION_CREATOR:
+        g_value_set_boolean (value, self->is_extension_creator);
+        break;
     case PROP_COMMENT:
         g_value_set_string (value, self->comment);
         break;
@@ -77,6 +82,9 @@ exm_comment_set_property (GObject      *object,
 
     switch (prop_id)
     {
+    case PROP_IS_EXTENSION_CREATOR:
+        self->is_extension_creator = g_value_get_boolean (value);
+        break;
     case PROP_COMMENT:
         self->comment = g_value_dup_string (value);
         break;
@@ -99,6 +107,13 @@ exm_comment_class_init (ExmCommentClass *klass)
     object_class->finalize = exm_comment_finalize;
     object_class->get_property = exm_comment_get_property;
     object_class->set_property = exm_comment_set_property;
+
+    properties [PROP_IS_EXTENSION_CREATOR] =
+        g_param_spec_boolean ("is_extension_creator",
+                              "Is Extension Creator",
+                              "Is the creator of the extension",
+                              FALSE,
+                              G_PARAM_READWRITE);
 
     properties [PROP_COMMENT] =
         g_param_spec_string ("comment",


### PR DESCRIPTION
Following a similar design to the extensions website.

![image](https://github.com/mjakeman/extension-manager/assets/42654671/02defd09-6c57-4753-b336-05d869ddd012)