### PR TITLE
comment-tile: Hide rating when zero

### DIFF
--- a/src/exm-comment-tile.blp
+++ b/src/exm-comment-tile.blp
@@ -18,7 +18,6 @@ template $ExmCommentTile : Gtk.Widget {
       Gtk.Label author_badge {
       	styles ["author-badge"]
       	label: _("Author");
-      	visible: false;
       }
 
       $ExmRating rating {

--- a/src/exm-comment-tile.c
+++ b/src/exm-comment-tile.c
@@ -98,7 +98,7 @@ exm_comment_tile_constructed (GObject *object)
                   "rating", &score,
                   NULL);
 
-    if (score >= 0 && score <= 5)
+    if (score >= 1 && score <= 5)
     {
         g_object_set (self->rating, "rating", score, NULL);
         gtk_widget_set_visible (GTK_WIDGET (self->rating), TRUE);


### PR DESCRIPTION
Following extensions website behavior. Also covers the case where the author of the comment is the extension's creator.