### PR TITLE
Syntax Error in data/meson.build: appstreamcli validate --nonet

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -44,7 +44,7 @@ appstream_file = i18n.merge_file(
 appstreamcli = find_program('appstreamcli', required: false)
 if appstreamcli.found()
   test('Validate appstream file', appstreamcli,
-    args: ['validate', '--nonet', '--explain', appstream_file]
+    args: ['validate', '--no-net', '--explain', appstream_file]
   )
 endif
 


### PR DESCRIPTION
This should be `--no-net`

```

3/3 Validate appstream file        FAIL            0.01s   exit status 1`
...
stdout:
Unknown option --nonet
```