### PR TITLE
browse-page: Treat hook to activate initial search in Blueprint

### DIFF
--- a/src/exm-browse-page.blp
+++ b/src/exm-browse-page.blp
@@ -19,9 +19,7 @@ template $ExmBrowsePage : Gtk.Widget {
 						Gtk.SearchEntry search_entry {
 							hexpand: true;
 
-							// Hook for triggering initial search
-							// TODO: Re-enable this once blueprint-compiler!4 is merged
-							// realize => on_search_entry_realize();
+							realize => $on_search_entry_realize();
 						}
 
 						// Keep the same order as the ExmSearchSort enum

--- a/src/exm-browse-page.c
+++ b/src/exm-browse-page.c
@@ -437,11 +437,6 @@ exm_browse_page_init (ExmBrowsePage *self)
                               G_CALLBACK (on_search_changed),
                               self);
 
-    g_signal_connect (self->search_entry,
-                      "realize",
-                      G_CALLBACK (on_search_entry_realize),
-                      self);
-
     g_signal_connect (self->more_results_btn,
                       "clicked",
                       G_CALLBACK (on_load_more_results),


### PR DESCRIPTION
Now that [blueprint-compiler!4](https://gitlab.gnome.org/jwestman/blueprint-compiler/-/merge_requests/4) is merged, we can enable it again.