### PR TITLE
detail-view: Add zoom shortcuts

### DIFF
--- a/src/exm-detail-view.c
+++ b/src/exm-detail-view.c
@@ -50,6 +50,7 @@ struct _ExmDetailView
 
   	GSimpleAction *zoom_in;
     GSimpleAction *zoom_out;
+    GSimpleAction *zoom_reset;
 
     gchar *shell_version;
     gchar *uuid;
@@ -599,6 +600,10 @@ exm_detail_view_class_init (ExmDetailViewClass *klass)
 
     gtk_widget_class_install_action (widget_class, "detail.open-extensions", NULL, open_link);
     gtk_widget_class_install_action (widget_class, "detail.open-homepage", NULL, open_link);
+
+    gtk_widget_class_add_binding_action (widget_class, GDK_KEY_plus, GDK_CONTROL_MASK, "detail.zoom-in", NULL);
+    gtk_widget_class_add_binding_action (widget_class, GDK_KEY_minus, GDK_CONTROL_MASK, "detail.zoom-out", NULL);
+    gtk_widget_class_add_binding_action (widget_class, GDK_KEY_0, GDK_CONTROL_MASK, "detail.zoom-reset", NULL);
 }
 
 static void
@@ -628,9 +633,13 @@ exm_detail_view_init (ExmDetailView *self)
 	self->zoom_out = g_simple_action_new ("zoom-out", NULL);
 	g_signal_connect_swapped (self->zoom_out, "activate", G_CALLBACK (exm_zoom_picture_zoom_out), self->overlay_screenshot);
 
+	self->zoom_reset = g_simple_action_new ("zoom-reset", NULL);
+	g_signal_connect_swapped (self->zoom_reset, "activate", G_CALLBACK (exm_zoom_picture_zoom_reset), self->overlay_screenshot);
+
 	group = g_simple_action_group_new ();
 	g_action_map_add_action (G_ACTION_MAP (group), G_ACTION (self->zoom_in));
 	g_action_map_add_action (G_ACTION_MAP (group), G_ACTION (self->zoom_out));
+	g_action_map_add_action (G_ACTION_MAP (group), G_ACTION (self->zoom_reset));
 	gtk_widget_insert_action_group (GTK_WIDGET (self), "detail", G_ACTION_GROUP (group));
 
     // Update action state on zoom change

--- a/src/exm-zoom-picture.c
+++ b/src/exm-zoom-picture.c
@@ -178,6 +178,12 @@ exm_zoom_picture_zoom_out (ExmZoomPicture *self)
 }
 
 void
+exm_zoom_picture_zoom_reset (ExmZoomPicture *self)
+{
+	exm_zoom_picture_set_zoom_level (self, 1);
+}
+
+void
 compute_scaled_dimensions (ExmZoomPicture *self)
 {
 	float width, height;

--- a/src/exm-zoom-picture.h
+++ b/src/exm-zoom-picture.h
@@ -44,6 +44,9 @@ void
 exm_zoom_picture_zoom_out (ExmZoomPicture *self);
 
 void
+exm_zoom_picture_zoom_reset (ExmZoomPicture *self);
+
+void
 exm_zoom_picture_set_zoom_level (ExmZoomPicture *self,
                                  float           zoom_level);
 


### PR DESCRIPTION
See https://developer.gnome.org/hig/reference/keyboard.html#view-options

~It would fit better if it was in `zoom-picture` but it doesn't work there. I guess there is something in the event propagation that I'm not getting.~