### PR TITLE
flatpak: Have stable and devel manifests in tree

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,6 @@ jobs:
     - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v6.3
       with:
         bundle: extension-manager.flatpak
-        manifest-path: com.mattjakeman.ExtensionManager.Devel.json
+        manifest-path: build-aux/com.mattjakeman.ExtensionManager.Devel.json
         cache-key: flatpak-builder-${{ github.sha }}
         run-tests: true

--- a/build-aux/com.mattjakeman.ExtensionManager.Devel.json
+++ b/build-aux/com.mattjakeman.ExtensionManager.Devel.json
@@ -1,0 +1,89 @@
+{
+    "id" : "com.mattjakeman.ExtensionManager.Devel",
+    "runtime" : "org.gnome.Platform",
+    "runtime-version" : "master",
+    "sdk" : "org.gnome.Sdk",
+    "command" : "extension-manager",
+    "separate-locales" : false,
+    "finish-args" : [
+        "--share=network",
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--device=dri",
+        "--socket=wayland",
+        "--talk-name=org.gnome.Shell.Extensions",
+        "--talk-name=org.gnome.SessionManager"
+    ],
+    "cleanup" : [
+        "/include",
+        "/lib/pkgconfig",
+        "/man",
+        "/share/doc",
+        "/share/gtk-doc",
+        "/share/man",
+        "/share/pkgconfig",
+        "*.la",
+        "*.a"
+    ],
+    "modules" : [
+    	{
+            "name" : "blueprint-compiler",
+            "builddir" : true,
+            "buildsystem" : "meson",
+            "cleanup" : [
+                "*"
+            ],
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://gitlab.gnome.org/jwestman/blueprint-compiler.git",
+                    "commit" : "2a39a16391122af2f3d812e478c1c1398c98b972",
+                    "tag" : "v0.10.0"
+                }
+            ]
+        },
+        {
+            "name" : "libbacktrace",
+            "builddir" : true,
+            "buildsystem" : "autotools",
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://github.com/ianlancetaylor/libbacktrace.git",
+                    "branch" : "master"
+                }
+            ]
+        },
+        {
+            "name" : "text-engine",
+            "builddir" : true,
+            "buildsystem" : "meson",
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://github.com/mjakeman/text-engine.git",
+                    "commit" : "379437b2b589a9414985dec9136b7b48bae76f9e",
+                    "tag" : "v0.1.0"
+                }
+            ]
+        },
+        {
+            "name" : "extension-manager",
+            "builddir" : true,
+            "buildsystem" : "meson",
+            "run-tests" : true,
+            "config-opts" : [
+                "-Ddevelopment=true",
+                "-Dpackage=Flatpak",
+                "-Ddistributor=mjakeman",
+                "-Dofficial=true"
+            ],
+            "sources" : [
+                {
+                    "type" : "dir",
+                    "path" : "../"
+                }
+            ]
+        }
+    ]
+}

--- a/build-aux/com.mattjakeman.ExtensionManager.json
+++ b/build-aux/com.mattjakeman.ExtensionManager.json
@@ -1,5 +1,5 @@
 {
-    "id" : "com.mattjakeman.ExtensionManager.Devel",
+    "id" : "com.mattjakeman.ExtensionManager",
     "runtime" : "org.gnome.Platform",
     "runtime-version" : "45",
     "sdk" : "org.gnome.Sdk",
@@ -49,43 +49,43 @@
             ]
         },
     	{
-            "name": "blueprint-compiler",
-            "builddir": true,
-            "buildsystem": "meson",
-            "cleanup": [
+            "name" : "blueprint-compiler",
+            "builddir" : true,
+            "buildsystem" : "meson",
+            "cleanup" : [
                 "*"
             ],
-            "sources": [
+            "sources" : [
                 {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler.git",
-                    "commit": "2a39a16391122af2f3d812e478c1c1398c98b972",
-                    "tag": "v0.10.0"
+                    "type" : "git",
+                    "url" : "https://gitlab.gnome.org/jwestman/blueprint-compiler.git",
+                    "commit" : "2a39a16391122af2f3d812e478c1c1398c98b972",
+                    "tag" : "v0.10.0"
                 }
             ]
         },
         {
-            "name": "libbacktrace",
-            "builddir": true,
-            "buildsystem": "autotools",
-            "sources": [
+            "name" : "libbacktrace",
+            "builddir" : true,
+            "buildsystem" : "autotools",
+            "sources" : [
                 {
-                    "type": "git",
-                    "url": "https://github.com/ianlancetaylor/libbacktrace.git",
-                    "branch": "master"
+                    "type" : "git",
+                    "url" : "https://github.com/ianlancetaylor/libbacktrace.git",
+                    "commit" : "9ae4f4ae4481b1e69d38ed810980d33103544613"
                 }
             ]
         },
         {
-            "name": "text-engine",
-            "builddir": true,
-            "buildsystem": "meson",
-            "sources": [
+            "name" : "text-engine",
+            "builddir" : true,
+            "buildsystem" : "meson",
+            "sources" : [
                 {
-                    "type": "git",
-                    "url": "https://github.com/mjakeman/text-engine.git",
-                    "commit": "379437b2b589a9414985dec9136b7b48bae76f9e",
-                    "tag": "v0.1.0"
+                    "type" : "git",
+                    "url" : "https://github.com/mjakeman/text-engine.git",
+                    "commit" : "379437b2b589a9414985dec9136b7b48bae76f9e",
+                    "tag" : "v0.1.0"
                 }
             ]
         },
@@ -94,13 +94,20 @@
             "builddir" : true,
             "buildsystem" : "meson",
             "build-options" : {
-            	"no-debuginfo" : true
+                "no-debuginfo" : true
             },
-            "config-opts" : [ "-Ddevelopment=true", "-Dpackage=Flatpak", "-Ddistributor=mjakeman", "-Dofficial=true" ],
+            "config-opts" : [
+                "-Ddevelopment=false",
+                "-Dpackage=Flatpak",
+                "-Ddistributor=mjakeman",
+                "-Dofficial=true"
+            ],
             "sources" : [
                 {
-                    "type" : "dir",
-                    "path" : "./"
+                    "type" : "git",
+                    "url" : "https://github.com/mjakeman/extension-manager",
+                    "commit" : "fce0e326dbddaf6ae17df79c01e553f4b73e3015",
+                    "tag" : "v0.4.3"
                 }
             ]
         }


### PR DESCRIPTION
With the master version of the runtime we can test the changes in the development versions of the libraries beforehand.

This also removes `webp-pixbuf-loader` from the modules in the devel manifest, as it will be included in the platform for GNOME 46. See https://gitlab.gnome.org/GNOME/gnome-build-meta/-/merge_requests/2507