### PR TITLE
extension-row: Escape title

### DIFF
--- a/src/exm-extension-row.c
+++ b/src/exm-extension-row.c
@@ -232,7 +232,7 @@ bind_extension (ExmExtensionRow *self,
 
     self->uuid = g_strdup (uuid);
 
-    g_object_set (self, "title", name, "subtitle", uuid, NULL);
+    g_object_set (self, "title", g_markup_escape_text(name, -1), "subtitle", uuid, NULL);
     g_object_set (self->prefs_btn, "visible", has_prefs, NULL);
     g_object_set (self->remove_btn, "visible", is_user, NULL);
     g_object_set (self->update_icon, "visible", has_update, NULL);


### PR DESCRIPTION
Escaping it here instead of `exm-extension` should hopefully fix extensions with special characters and avoid issues anywhere else.

Fix https://github.com/mjakeman/extension-manager/issues/473