### PR TITLE
search-row: Use GtkExpression lookups in Blueprint

### DIFF
--- a/src/exm-search-row.blp
+++ b/src/exm-search-row.blp
@@ -1,80 +1,91 @@
 using Gtk 4.0;
 using Adw 1;
 
-template $ExmSearchRow : Gtk.ListBoxRow {
-	styles ["search-row"]
+template $ExmSearchRow: Gtk.ListBoxRow {
+  styles [
+    "search-row"
+  ]
 
-	activatable: true;
-	action-name: "win.show-detail";
+  activatable: true;
+  action-name: "win.show-detail";
 
-	Gtk.Box header {
-		styles ["header"]
-		hexpand: true;
-		spacing: 10;
+  Gtk.Box header {
+    styles [
+      "header"
+    ]
 
-		Gtk.Grid {
-			hexpand: true;
-			column-spacing:  10;
+    hexpand: true;
+    spacing: 10;
 
-			Gtk.Box {
-				hexpand: true;
-				orientation: vertical;
-				valign: center;
+    Gtk.Grid {
+      hexpand: true;
+      column-spacing: 10;
 
-				Gtk.Label title {
-					styles ["title"]
-					ellipsize: end;
-					xalign: 0;
+      Gtk.Box {
+        hexpand: true;
+        orientation: vertical;
+        valign: center;
 
-					label: bind template.search-result as <$ExmSearchResult>.name;
-				}
+        Gtk.Label title {
+          styles [
+            "title"
+          ]
 
-				Gtk.Label subtitle {
-					styles ["subtitle"]
-					ellipsize: end;
-					xalign: 0;
+          ellipsize: end;
+          xalign: 0;
+          label: bind template.search-result as <$ExmSearchResult>.name;
+        }
 
-					label: bind template.search-result as <$ExmSearchResult>.creator;
-				}
+        Gtk.Label subtitle {
+          styles [
+            "subtitle"
+          ]
 
-				layout {
-					row: 0;
-					column: 1;
-				}
-			}
+          ellipsize: end;
+          xalign: 0;
+          label: bind template.search-result as <$ExmSearchResult>.creator;
+        }
 
-			Gtk.Label description_label {
-				styles ["dim-label"]
+        layout {
+          row: 0;
+          column: 1;
+        }
+      }
 
-				margin-top: 5;
-				single-line-mode: true;
-				xalign: 0;
-				wrap: true;
-				wrap-mode: word_char;
-				ellipsize: end;
-				lines: 2;
+      Gtk.Label description_label {
+        styles [
+          "dim-label"
+        ]
 
-				label: bind template.search-result as <$ExmSearchResult>.description;
+        margin-top: 5;
+        single-line-mode: true;
+        xalign: 0;
+        wrap: true;
+        wrap-mode: word_char;
+        ellipsize: end;
+        lines: 2;
+        label: bind template.search-result as <$ExmSearchResult>.description;
 
-				layout {
-					row: 1;
-					column: 1;
-				}
-			}
-		}
+        layout {
+          row: 1;
+          column: 1;
+        }
+      }
+    }
 
-		$ExmInstallButton install_btn {
-			valign: center;
-			halign: end;
-		}
+    $ExmInstallButton install_btn {
+      valign: center;
+      halign: end;
+    }
 
-		Gtk.Image {
-			styles ["expander-row-arrow"]
+    Gtk.Image {
+      styles [
+        "expander-row-arrow"
+      ]
 
-			valign: center;
-			halign: end;
-
-			icon-name: "go-next-symbolic";
-		}
-	}
+      valign: center;
+      halign: end;
+      icon-name: "go-next-symbolic";
+    }
+  }
 }

--- a/src/exm-search-row.blp
+++ b/src/exm-search-row.blp
@@ -5,6 +5,7 @@ template $ExmSearchRow : Gtk.ListBoxRow {
 	styles ["search-row"]
 
 	activatable: true;
+	action-name: "win.show-detail";
 
 	Gtk.Box header {
 		styles ["header"]
@@ -24,12 +25,16 @@ template $ExmSearchRow : Gtk.ListBoxRow {
 					styles ["title"]
 					ellipsize: end;
 					xalign: 0;
+
+					label: bind template.search-result as <$ExmSearchResult>.name;
 				}
 
 				Gtk.Label subtitle {
 					styles ["subtitle"]
 					ellipsize: end;
 					xalign: 0;
+
+					label: bind template.search-result as <$ExmSearchResult>.creator;
 				}
 
 				layout {
@@ -48,6 +53,8 @@ template $ExmSearchRow : Gtk.ListBoxRow {
 				wrap-mode: word_char;
 				ellipsize: end;
 				lines: 2;
+
+				label: bind template.search-result as <$ExmSearchResult>.description;
 
 				layout {
 					row: 1;

--- a/src/exm-search-row.c
+++ b/src/exm-search-row.c
@@ -16,10 +16,7 @@ struct _ExmSearchRow
     gboolean is_supported;
     gchar *uuid;
 
-    GtkLabel *description_label;
     ExmInstallButton *install_btn;
-    GtkLabel *title;
-    GtkLabel *subtitle;
 };
 
 G_DEFINE_FINAL_TYPE (ExmSearchRow, exm_search_row, GTK_TYPE_LIST_BOX_ROW)
@@ -127,41 +124,16 @@ install_remote (GtkButton    *button,
 static void
 exm_search_row_constructed (GObject *object)
 {
-    // TODO: This big block of property assignments is currently copy/pasted
-    // from ExmExtension. We can replace this with GtkExpression lookups
-    // once blueprint-compiler supports expressions.
-    // (See https://gitlab.gnome.org/jwestman/blueprint-compiler/-/issues/5)
-
     ExmSearchRow *self = EXM_SEARCH_ROW (object);
 
     ExmInstallButtonState install_state;
 
-    gchar *uri;
-    int pk;
-
-    gchar *uuid, *name, *creator, *icon_uri, *screenshot_uri, *link, *description;
+    gchar *uuid;
     g_object_get (self->search_result,
                   "uuid", &uuid,
-                  "name", &name,
-                  "creator", &creator,
-                  "icon", &icon_uri,
-                  "screenshot", &screenshot_uri,
-                  "link", &link,
-                  "description", &description,
-                  "pk", &pk,
                   NULL);
 
-    uri = g_uri_resolve_relative ("https://extensions.gnome.org/",
-                                  link,
-                                  G_URI_FLAGS_NONE,
-                                  NULL);
-
-    gtk_actionable_set_action_name (GTK_ACTIONABLE (self), "win.show-detail");
     gtk_actionable_set_action_target (GTK_ACTIONABLE (self), "s", uuid);
-
-    gtk_label_set_label (self->title, name);
-    gtk_label_set_label (self->subtitle, creator);
-    gtk_label_set_label (self->description_label, description);
 
     install_state = self->is_installed
         ? EXM_INSTALL_BUTTON_STATE_INSTALLED
@@ -212,10 +184,7 @@ exm_search_row_class_init (ExmSearchRowClass *klass)
 
     gtk_widget_class_set_template_from_resource (widget_class, "/com/mattjakeman/ExtensionManager/exm-search-row.ui");
 
-    gtk_widget_class_bind_template_child (widget_class, ExmSearchRow, description_label);
     gtk_widget_class_bind_template_child (widget_class, ExmSearchRow, install_btn);
-    gtk_widget_class_bind_template_child (widget_class, ExmSearchRow, title);
-    gtk_widget_class_bind_template_child (widget_class, ExmSearchRow, subtitle);
 }
 
 static void


### PR DESCRIPTION
I also took the opportunity to run the new formatter (`blueprint-compiler format`).

It remains to do the same with `extension-row`, which will be better to do in or after #517.