### PR TITLE
Port to libadwaita 1.5 widgets

### DIFF
--- a/src/exm-application.c
+++ b/src/exm-application.c
@@ -162,45 +162,43 @@ exm_application_show_about (GSimpleAction *action,
     GtkWindow *window = NULL;
     const gchar *authors[] = {"Matthew Jakeman", NULL};
 
-    GtkWidget *about_window;
+    AdwDialog *about_dialog;
 
     g_return_if_fail (EXM_IS_APPLICATION (self));
 
     window = gtk_application_get_active_window (GTK_APPLICATION (self));
 
-    about_window = adw_about_window_new_from_appdata ("/com/mattjakeman/ExtensionManager/com.mattjakeman.ExtensionManager.metainfo.xml",
+    about_dialog = adw_about_dialog_new_from_appdata ("/com/mattjakeman/ExtensionManager/com.mattjakeman.ExtensionManager.metainfo.xml",
                                                       strstr (APP_ID, ".Devel") == NULL ? APP_VERSION : NULL);
-    gtk_window_set_modal (GTK_WINDOW (about_window), TRUE);
-    gtk_window_set_transient_for (GTK_WINDOW (about_window), window);
 
-    adw_about_window_set_version (ADW_ABOUT_WINDOW (about_window), APP_VERSION);
-    adw_about_window_set_comments (ADW_ABOUT_WINDOW (about_window), _("Browse, install, and manage GNOME Shell Extensions."));
-    adw_about_window_set_developers (ADW_ABOUT_WINDOW (about_window), authors);
-    adw_about_window_set_translator_credits (ADW_ABOUT_WINDOW (about_window), _("translator-credits"));
-    adw_about_window_set_copyright (ADW_ABOUT_WINDOW (about_window), "© 2022 Matthew Jakeman");
+    adw_about_dialog_set_version (ADW_ABOUT_DIALOG (about_dialog), APP_VERSION);
+    adw_about_dialog_set_comments (ADW_ABOUT_DIALOG (about_dialog), _("Browse, install, and manage GNOME Shell Extensions."));
+    adw_about_dialog_set_developers (ADW_ABOUT_DIALOG (about_dialog), authors);
+    adw_about_dialog_set_translator_credits (ADW_ABOUT_DIALOG (about_dialog), _("translator-credits"));
+    adw_about_dialog_set_copyright (ADW_ABOUT_DIALOG (about_dialog), "© 2022 Matthew Jakeman");
 
     // Dependency Attribution
-    adw_about_window_add_legal_section (ADW_ABOUT_WINDOW (about_window),
+    adw_about_dialog_add_legal_section (ADW_ABOUT_DIALOG (about_dialog),
                                         "text-engine",
                                         "Copyright (C) 2022 Matthew Jakeman",
                                         GTK_LICENSE_MPL_2_0,
                                         NULL);
 
 #if WITH_BACKTRACE
-    adw_about_window_add_legal_section (ADW_ABOUT_WINDOW (about_window),
+    adw_about_dialog_add_legal_section (ADW_ABOUT_DIALOG (about_dialog),
                                         "libbacktrace",
                                         "Copyright (C) 2012-2016 Free Software Foundation, Inc.",
                                         GTK_LICENSE_BSD_3,
                                         NULL);
 #endif
 
-    adw_about_window_add_legal_section (ADW_ABOUT_WINDOW (about_window),
+    adw_about_dialog_add_legal_section (ADW_ABOUT_DIALOG (about_dialog),
                                         "blueprint",
                                         "Copyright (C) 2021 James Westman",
                                         GTK_LICENSE_LGPL_3_0,
                                         NULL);
 
-    gtk_window_present (GTK_WINDOW (about_window));
+    adw_dialog_present (about_dialog, GTK_WIDGET (window));
 }
 
 static void

--- a/src/exm-comment-dialog.blp
+++ b/src/exm-comment-dialog.blp
@@ -1,14 +1,14 @@
 using Gtk 4.0;
 using Adw 1;
 
-template $ExmCommentDialog : Adw.Window {
-  default-width: 600;
-  default-height: 500;
+template $ExmCommentDialog : Adw.Dialog {
+  content-width: 600;
+  content-height: 600;
   width-request: 360;
   height-request: 294;
   title: _("Comments");
 
-  Adw.ToolbarView {
+  child: Adw.ToolbarView {
 
     [top]
     Adw.HeaderBar {}
@@ -50,5 +50,5 @@ template $ExmCommentDialog : Adw.Window {
         }
       }
     };
-  }
+  };
 }

--- a/src/exm-comment-dialog.c
+++ b/src/exm-comment-dialog.c
@@ -7,7 +7,7 @@
 
 struct _ExmCommentDialog
 {
-    AdwWindow parent_instance;
+    AdwDialog parent_instance;
 
     ExmCommentProvider *comment_provider;
 
@@ -17,7 +17,7 @@ struct _ExmCommentDialog
     int web_id;
 };
 
-G_DEFINE_FINAL_TYPE (ExmCommentDialog, exm_comment_dialog, ADW_TYPE_WINDOW)
+G_DEFINE_FINAL_TYPE (ExmCommentDialog, exm_comment_dialog, ADW_TYPE_DIALOG)
 
 enum {
     PROP_0,
@@ -106,8 +106,6 @@ exm_comment_dialog_class_init (ExmCommentDialogClass *klass)
 
     gtk_widget_class_bind_template_child (widget_class, ExmCommentDialog, list_box);
     gtk_widget_class_bind_template_child (widget_class, ExmCommentDialog, stack);
-
-    gtk_widget_class_add_binding_action (widget_class, GDK_KEY_Escape, 0, "window.close", NULL);
 }
 
 static GtkWidget *

--- a/src/exm-comment-dialog.h
+++ b/src/exm-comment-dialog.h
@@ -8,7 +8,7 @@ G_BEGIN_DECLS
 
 #define EXM_TYPE_COMMENT_DIALOG (exm_comment_dialog_get_type())
 
-G_DECLARE_FINAL_TYPE (ExmCommentDialog, exm_comment_dialog, EXM, COMMENT_DIALOG, AdwWindow)
+G_DECLARE_FINAL_TYPE (ExmCommentDialog, exm_comment_dialog, EXM, COMMENT_DIALOG, AdwDialog)
 
 ExmCommentDialog *exm_comment_dialog_new (int web_id);
 

--- a/src/exm-detail-view.c
+++ b/src/exm-detail-view.c
@@ -271,10 +271,7 @@ show_more_comments (GtkButton *button,
     dlg = exm_comment_dialog_new (self->pk);
     toplevel = gtk_widget_get_root (GTK_WIDGET (self));
 
-    gtk_window_set_transient_for (GTK_WINDOW (dlg), GTK_WINDOW (toplevel));
-    gtk_window_set_modal (GTK_WINDOW (dlg), TRUE);
-
-    gtk_window_present (GTK_WINDOW (dlg));
+    adw_dialog_present (ADW_DIALOG (dlg), GTK_WIDGET (toplevel));
 }
 
 static void

--- a/src/exm-upgrade-assistant.blp
+++ b/src/exm-upgrade-assistant.blp
@@ -1,13 +1,13 @@
 using Gtk 4.0;
 using Adw 1;
 
-template $ExmUpgradeAssistant : Adw.Window {
-  default-width: 400;
-  default-height: 550;
+template $ExmUpgradeAssistant : Adw.Dialog {
+  content-width: 400;
+  content-height: 600;
   title: _("Upgrade Assistant");
   notify::manager => $on_bind_manager();
 
-  Adw.ToolbarView {
+  child: Adw.ToolbarView {
 
     [top]
     Adw.HeaderBar {}
@@ -136,5 +136,5 @@ template $ExmUpgradeAssistant : Adw.Window {
         };
       }
     };
-  }
+  };
 }

--- a/src/exm-upgrade-assistant.c
+++ b/src/exm-upgrade-assistant.c
@@ -28,7 +28,7 @@
 
 struct _ExmUpgradeAssistant
 {
-    AdwWindow parent_instance;
+    AdwDialog parent_instance;
 
     // Auxiliary Classes
     ExmManager *manager;
@@ -66,7 +66,7 @@ struct _ExmUpgradeAssistant
     GtkButton *copy_details;
 };
 
-G_DEFINE_FINAL_TYPE (ExmUpgradeAssistant, exm_upgrade_assistant, ADW_TYPE_WINDOW)
+G_DEFINE_FINAL_TYPE (ExmUpgradeAssistant, exm_upgrade_assistant, ADW_TYPE_DIALOG)
 
 enum {
     PROP_0,
@@ -657,8 +657,6 @@ exm_upgrade_assistant_class_init (ExmUpgradeAssistantClass *klass)
     gtk_widget_class_bind_template_callback (widget_class, do_compatibility_check);
     gtk_widget_class_bind_template_callback (widget_class, copy_to_clipboard);
     gtk_widget_class_bind_template_callback (widget_class, on_bind_manager);
-
-    gtk_widget_class_add_binding_action (widget_class, GDK_KEY_Escape, 0, "window.close", NULL);
 }
 
 static void

--- a/src/exm-upgrade-assistant.h
+++ b/src/exm-upgrade-assistant.h
@@ -28,7 +28,7 @@
  
  #define EXM_TYPE_UPGRADE_ASSISTANT (exm_upgrade_assistant_get_type())
  
- G_DECLARE_FINAL_TYPE (ExmUpgradeAssistant, exm_upgrade_assistant, EXM, UPGRADE_ASSISTANT, AdwWindow)
+ G_DECLARE_FINAL_TYPE (ExmUpgradeAssistant, exm_upgrade_assistant, EXM, UPGRADE_ASSISTANT, AdwDialog)
  
  ExmUpgradeAssistant *exm_upgrade_assistant_new (ExmManager *manager);
 

--- a/src/exm-window.c
+++ b/src/exm-window.c
@@ -145,11 +145,11 @@ typedef struct
 } RemoveDialogData;
 
 static void
-extension_remove_dialog_response (GtkDialog        *dialog,
+extension_remove_dialog_response (AdwDialog        *dialog,
                                   const char       *response,
                                   RemoveDialogData *data)
 {
-    gtk_window_destroy (GTK_WINDOW (dialog));
+    adw_dialog_force_close (dialog);
 
     if (strcmp(response, "yes") == 0)
     {
@@ -175,28 +175,27 @@ extension_remove (GtkWidget  *widget,
 
     extension = exm_manager_get_by_uuid (self->manager, uuid);
 
-    GtkWidget *dlg;
+    AdwDialog *dlg;
 
-    dlg = adw_message_dialog_new (GTK_WINDOW (self),
-                                  _("Uninstall Extension?"),
-                                  _("The extension's features and functionality will no longer be accessible. Are you sure you want to uninstall?"));
+    dlg = adw_alert_dialog_new (_("Uninstall Extension?"),
+                                _("The extension's features and functionality will no longer be accessible. Are you sure you want to uninstall?"));
 
-    adw_message_dialog_add_responses (ADW_MESSAGE_DIALOG (dlg),
-                                      "no", _("_No"),
-                                      "yes", _("_Yes"),
-                                      NULL);
+    adw_alert_dialog_add_responses (ADW_ALERT_DIALOG (dlg),
+                                    "no", _("_No"),
+                                    "yes", _("_Yes"),
+                                    NULL);
 
-    adw_message_dialog_set_response_appearance (ADW_MESSAGE_DIALOG (dlg), "yes", ADW_RESPONSE_DESTRUCTIVE);
+    adw_alert_dialog_set_response_appearance (ADW_ALERT_DIALOG (dlg), "yes", ADW_RESPONSE_DESTRUCTIVE);
 
-    adw_message_dialog_set_default_response (ADW_MESSAGE_DIALOG (dlg), "no");
-    adw_message_dialog_set_close_response (ADW_MESSAGE_DIALOG (dlg), "no");
+    adw_alert_dialog_set_default_response (ADW_ALERT_DIALOG (dlg), "no");
+    adw_alert_dialog_set_close_response (ADW_ALERT_DIALOG (dlg), "no");
 
     RemoveDialogData *data = g_new0 (RemoveDialogData, 1);
     data->manager = g_object_ref (self->manager);
     data->extension = g_object_ref (extension);
 
     g_signal_connect (dlg, "response", G_CALLBACK (extension_remove_dialog_response), data);
-    gtk_window_present (GTK_WINDOW (dlg));
+    adw_dialog_present (dlg, GTK_WIDGET (self));
 }
 
 static void
@@ -218,11 +217,11 @@ typedef struct
 } UnsupportedDialogData;
 
 static void
-extension_unsupported_dialog_response (GtkDialog             *dialog,
+extension_unsupported_dialog_response (AdwDialog             *dialog,
                                        const char            *response,
                                        UnsupportedDialogData *data)
 {
-    gtk_window_destroy (GTK_WINDOW (dialog));
+    adw_dialog_force_close (dialog);
 
     if (strcmp(response, "yes") == 0)
     {
@@ -250,29 +249,28 @@ extension_install (GtkWidget  *widget,
 
     if (warn)
     {
-        GtkWidget *dlg;
+        AdwDialog *dlg;
 
-        dlg = adw_message_dialog_new (GTK_WINDOW (self),
-                                      _("Unsupported Extension"),
-                                      _("This extension does not support your GNOME Shell version. It may cause errors if installed."));
+        dlg = adw_alert_dialog_new (_("Unsupported Extension"),
+                                    _("This extension does not support your GNOME Shell version. It may cause errors if installed."));
 
-        adw_message_dialog_add_responses (ADW_MESSAGE_DIALOG (dlg),
-                                          "yes", _("_Install Anyway"),
-                                          "no", _("_Go Back"),
-                                          NULL);
+        adw_alert_dialog_add_responses (ADW_ALERT_DIALOG (dlg),
+                                        "yes", _("_Install Anyway"),
+                                        "no", _("_Go Back"),
+                                        NULL);
 
-        adw_message_dialog_set_response_appearance (ADW_MESSAGE_DIALOG (dlg), "yes", ADW_RESPONSE_DESTRUCTIVE);
-        adw_message_dialog_set_response_appearance (ADW_MESSAGE_DIALOG (dlg), "no", ADW_RESPONSE_SUGGESTED);
+        adw_alert_dialog_set_response_appearance (ADW_ALERT_DIALOG (dlg), "yes", ADW_RESPONSE_DESTRUCTIVE);
+        adw_alert_dialog_set_response_appearance (ADW_ALERT_DIALOG (dlg), "no", ADW_RESPONSE_SUGGESTED);
 
-        adw_message_dialog_set_default_response (ADW_MESSAGE_DIALOG (dlg), "no");
-        adw_message_dialog_set_close_response (ADW_MESSAGE_DIALOG (dlg), "no");
+        adw_alert_dialog_set_default_response (ADW_ALERT_DIALOG (dlg), "no");
+        adw_alert_dialog_set_close_response (ADW_ALERT_DIALOG (dlg), "no");
 
         UnsupportedDialogData *data = g_new0 (UnsupportedDialogData, 1);
         data->manager = g_object_ref (self->manager);
         data->uuid = g_strdup (uuid);
 
         g_signal_connect (dlg, "response", G_CALLBACK (extension_unsupported_dialog_response), data);
-        gtk_window_present (GTK_WINDOW (dlg));
+        adw_dialog_present (dlg, GTK_WIDGET (self));
 
         return;
     }

--- a/src/exm-window.c
+++ b/src/exm-window.c
@@ -332,9 +332,7 @@ show_upgrade_assistant (GtkWidget  *widget,
     self = EXM_WINDOW (widget);
 
     ExmUpgradeAssistant *assistant = exm_upgrade_assistant_new (self->manager);
-    gtk_window_set_modal (GTK_WINDOW (assistant), TRUE);
-    gtk_window_set_transient_for (GTK_WINDOW (assistant), GTK_WINDOW (self));
-    gtk_window_present (GTK_WINDOW (assistant));
+    adw_dialog_present (ADW_DIALOG (assistant), widget);
 }
 
 static void


### PR DESCRIPTION
Requires `master` runtime-version.

Following https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/migrating-to-adaptive-dialogs.html