### PR TITLE
upgrade-assistant: Fix GNOME version calculation

### DIFF
--- a/src/exm-upgrade-assistant.c
+++ b/src/exm-upgrade-assistant.c
@@ -573,10 +573,12 @@ populate_drop_down (ExmUpgradeAssistant *self)
     // GNOME 40 came out in March 2021
     current_gnome_version = 40 + (year - 2021) * 2;
 
-    // If we are between september and march, then it is
-    // an odd numbered release, otherwise use an even numbered
+    // If we are between march and september, then it is
+    // an even numbered release, otherwise use an odd numbered
     // release.
-    if (month >= G_DATE_SEPTEMBER || month < G_DATE_MARCH)
+    if (month < G_DATE_MARCH)
+        current_gnome_version -= 1;
+    else if (month >= G_DATE_SEPTEMBER)
         current_gnome_version += 1;
 
     g_print ("Current GNOME Version: %d\n", current_gnome_version);


### PR DESCRIPTION
With the new year, two new versions of GNOME have been added that have not yet been released. To fix this, since the calculation based on the release date of GNOME 40 always results in the first version to be released in March of that year, which is even, then:
- If the month is prior to March, subtract one from the approximation, leaving the odd-numbered version released in September of the previous year.
- If the month is between March and September, we keep the value.
- If the month is September or later, we add one to get the odd numbered version of the year.