### PR TITLE
build: Use version suffix instead of name suffix

### DIFF
--- a/data/com.mattjakeman.ExtensionManager.desktop.in.in
+++ b/data/com.mattjakeman.ExtensionManager.desktop.in.in
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=@app_title@
+Name=Extension Manager
 Exec=extension-manager %U
 Icon=@app_id@
 Terminal=false

--- a/data/com.mattjakeman.ExtensionManager.metainfo.xml.in.in
+++ b/data/com.mattjakeman.ExtensionManager.metainfo.xml.in.in
@@ -3,7 +3,7 @@
 	<id>@app_id@.desktop</id>
 	<metadata_license>CC0-1.0</metadata_license>
 	<project_license>GPL-3.0-or-later</project_license>
-  <name>@app_title@</name>
+  <name>Extension Manager</name>
   <summary>Browse, install, and manage GNOME Shell Extensions</summary>
   <content_rating type="oars-1.1" />
   <developer_name translatable="no">Matthew Jakeman</developer_name>

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,7 +1,5 @@
 desktop_file_in_config = configuration_data()
 desktop_file_in_config.set('app_id', app_id)
-desktop_file_in_config.set('app_title', app_title)
-desktop_file_in_config.set('app_version', meson.project_version())
 desktop_file_in = configure_file(
           input: 'com.mattjakeman.ExtensionManager.desktop.in.in',
          output: '@0@.desktop.in'.format(app_id),
@@ -26,7 +24,6 @@ endif
 
 appconf = configuration_data()
 appconf.set('app_id', app_id)
-appconf.set('app_title', app_title)
 appstream_file_in = configure_file(
           input: 'com.mattjakeman.ExtensionManager.metainfo.xml.in.in',
          output: 'com.mattjakeman.ExtensionManager.metainfo.xml.in',

--- a/meson.build
+++ b/meson.build
@@ -9,22 +9,26 @@ project('extension-manager', 'c',
 i18n = import('i18n')
 
 if get_option('development')
-  app_title = 'Extension Manager (Development)'
   app_id = 'com.mattjakeman.ExtensionManager.Devel'
+  vcs_tag = run_command('git', 'rev-parse', '--short', 'HEAD', check: false).stdout().strip()
+  if vcs_tag == ''
+    version_suffix = '-devel'
+  else
+    version_suffix = '-@0@'.format(vcs_tag)
+  endif
 else
-  app_title = 'Extension Manager'
   app_id = 'com.mattjakeman.ExtensionManager'
+  version_suffix = ''
 endif
 
 config_h = configuration_data()
-config_h.set_quoted('APP_VERSION', meson.project_version())
+config_h.set_quoted('APP_VERSION', meson.project_version() + version_suffix)
 config_h.set_quoted('GETTEXT_PACKAGE', 'extension-manager')
 config_h.set_quoted('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
 config_h.set_quoted('APP_ID', app_id)
 config_h.set_quoted('PKG_NAME', get_option('package'))
 config_h.set_quoted('PKG_DISTRIBUTOR', get_option('distributor'))
 config_h.set10('IS_OFFICIAL', get_option('official'))
-config_h.set10('IS_DEVEL', get_option('development'))
 config_h.set10('WITH_BACKTRACE', get_option('backtrace'))
 configure_file(
   output: 'exm-config.h',

--- a/src/exm-application.c
+++ b/src/exm-application.c
@@ -168,10 +168,12 @@ exm_application_show_about (GSimpleAction *action,
 
     window = gtk_application_get_active_window (GTK_APPLICATION (self));
 
-    about_window = adw_about_window_new_from_appdata ("/com/mattjakeman/ExtensionManager/com.mattjakeman.ExtensionManager.metainfo.xml", APP_VERSION);
+    about_window = adw_about_window_new_from_appdata ("/com/mattjakeman/ExtensionManager/com.mattjakeman.ExtensionManager.metainfo.xml",
+                                                      strstr (APP_ID, ".Devel") == NULL ? APP_VERSION : NULL);
     gtk_window_set_modal (GTK_WINDOW (about_window), TRUE);
     gtk_window_set_transient_for (GTK_WINDOW (about_window), window);
 
+    adw_about_window_set_version (ADW_ABOUT_WINDOW (about_window), APP_VERSION);
     adw_about_window_set_comments (ADW_ABOUT_WINDOW (about_window), _("Browse, install, and manage GNOME Shell Extensions."));
     adw_about_window_set_developers (ADW_ABOUT_WINDOW (about_window), authors);
     adw_about_window_set_translator_credits (ADW_ABOUT_WINDOW (about_window), _("translator-credits"));

--- a/src/exm-error-dialog.c
+++ b/src/exm-error-dialog.c
@@ -101,7 +101,6 @@ exm_error_dialog_set_property (GObject      *object,
         GString *string_builder = g_string_new ("Support Log\n");
         g_string_append_printf (string_builder, "----\n");
         g_string_append_printf (string_builder, "Version: %s\n", APP_VERSION);
-        g_string_append_printf (string_builder, "Development: %s\n", IS_DEVEL ? "Yes" : "No");
         g_string_append_printf (string_builder, "Package Format: %s\n", PKG_NAME);
         g_string_append_printf (string_builder, "Status: %s\n", IS_OFFICIAL ? "Official" : "Third Party");
         g_string_append_printf (string_builder, "----\n");

--- a/src/exm-window.blp
+++ b/src/exm-window.blp
@@ -6,6 +6,7 @@ template $ExmWindow : Adw.ApplicationWindow {
   default-height: 600;
   width-request: 360;
   height-request: 294;
+  title: _("Extension Manager");
 
   Adw.Breakpoint main_breakpoint {
     condition ("max-width: 400sp")
@@ -20,6 +21,7 @@ template $ExmWindow : Adw.ApplicationWindow {
 
       Adw.NavigationPage main_view {
         can-pop: false;
+        title: bind template.title;
 
         Adw.ToolbarView {
 

--- a/src/exm-window.c
+++ b/src/exm-window.c
@@ -454,21 +454,14 @@ do_version_check (ExmWindow *self)
 static void
 exm_window_init (ExmWindow *self)
 {
-    gchar *title;
-
     gtk_widget_init_template (GTK_WIDGET (self));
 
-    if (IS_DEVEL) {
+    if (strstr (APP_ID, ".Devel") != NULL) {
         gtk_widget_add_css_class (GTK_WIDGET (self), "devel");
     }
 
     self->manager = exm_manager_new ();
     g_signal_connect (self->manager, "error-occurred", on_error, self);
-
-    title = IS_DEVEL ? _("Extension Manager (Development)") : _("Extension Manager");
-
-    gtk_window_set_title (GTK_WINDOW (self), title);
-    adw_navigation_page_set_title (self->main_view, title);
 
     g_object_set (self->installed_page, "manager", self->manager, NULL);
     g_object_set (self->browse_page, "manager", self->manager, NULL);


### PR DESCRIPTION
Over the last cycles, apps added to GNOME core are not using the suffix in their names for development versions. Instead, they are adding a suffix to the app version following the running commit. Since it simplifies build files a bit and translators work, let's go that route as well.