### PR TITLE
extension-row: Set error label wrap mode to word_char

### DIFF
--- a/src/exm-extension-row.blp
+++ b/src/exm-extension-row.blp
@@ -152,7 +152,7 @@ template $ExmExtensionRow : Adw.ExpanderRow {
 
 			Gtk.Label error_label {
 				xalign: 0;
-				wrap-mode: word;
+				wrap-mode: word_char;
 				wrap: true;
 				selectable: true;
 


### PR DESCRIPTION
Fixes some cases where error labels could force the horizontal scrollbar to show when the width of the application window was small.

| master  | PR |
| ------------- | ------------- |
| ![](https://github.com/mjakeman/extension-manager/assets/42654671/7ee63cf3-0442-4e58-9a18-99afa0592cff) | ![](https://github.com/mjakeman/extension-manager/assets/42654671/c87ab81b-262b-41a0-b85c-684cf485d88d) |