### PR TITLE
metainfo: Fix developer id

### DIFF
--- a/data/com.mattjakeman.ExtensionManager.metainfo.xml.in.in
+++ b/data/com.mattjakeman.ExtensionManager.metainfo.xml.in.in
@@ -6,8 +6,7 @@
   <name>Extension Manager</name>
   <summary>Browse, install, and manage GNOME Shell Extensions</summary>
   <content_rating type="oars-1.1" />
-  <developer_name translatable="no">Matthew Jakeman</developer_name>
-  <developer id="mattjakeman.com">
+  <developer id="com.mattjakeman">
     <name translatable="no">Matthew Jakeman</name>
   </developer>
 	<description>


### PR DESCRIPTION
AppStream now recommends a reverse-DNS name, see https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer

Also, drop developer_name tag as Flathub has already switched to libappstream, see https://docs.flathub.org/blog/improved-build-validation