### PR TITLE
metainfo: Add brand colors

### DIFF
--- a/data/com.mattjakeman.ExtensionManager.metainfo.xml.in.in
+++ b/data/com.mattjakeman.ExtensionManager.metainfo.xml.in.in
@@ -48,6 +48,10 @@
   <requires>
     <display_length compare="ge">360</display_length>
   </requires>
+  <branding>
+    <color type="primary" scheme_preference="light">#95d1ff</color>
+    <color type="primary" scheme_preference="dark">#005edf</color>
+  </branding>
   <releases>
     <release version="0.5.1" date="2024-04-29">
       <description translate="no">


### PR DESCRIPTION
See https://docs.flathub.org/blog/introducing-app-brand-colors/

Taken from homepage https://mattjakeman.com/apps/extension-manager.html

| Light | Dark |
| -------- | ------- |
| ![image](https://github.com/mjakeman/extension-manager/assets/42654671/5457eb57-7271-4e2d-a05c-cd53d17aa72c) | ![image](https://github.com/mjakeman/extension-manager/assets/42654671/4a47e1fa-cffc-4869-916d-194be4d03455) |