### PR TITLE
detail-view: Split screenshot overlay into its own view

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -25,6 +25,8 @@ src/exm-rating.blp
 src/exm-rating.c
 src/exm-screenshot.blp
 src/exm-screenshot.c
+src/exm-screenshot-view.blp
+src/exm-screenshot-view.c
 src/exm-search-row.blp
 src/exm-search-row.c
 src/exm-upgrade-assistant.blp

--- a/src/exm-detail-view.blp
+++ b/src/exm-detail-view.blp
@@ -2,7 +2,6 @@ using Gtk 4.0;
 using Adw 1;
 
 template $ExmDetailView : Adw.NavigationPage {
-
 	Adw.ToolbarView {
 
 		[top]
@@ -26,309 +25,251 @@ template $ExmDetailView : Adw.NavigationPage {
 				unapply => $breakpoint_unapply_cb() swapped;
 			}
 
-			Gtk.Overlay {
-				[overlay]
-				Gtk.Overlay image_overlay {
-					visible: false;
+			Gtk.Stack stack {
+				vexpand: true;
 
-					[overlay]
-					Gtk.Box {
-						orientation: horizontal;
-						spacing: 16;
+				Gtk.StackPage {
+					name: "page_spinner";
 
-						halign: end;
-						valign: end;
+					child: Gtk.Box {
+						orientation: vertical;
+						spacing: 24;
+						valign: center;
 
-						margin-top: 24;
-						margin-bottom: 24;
-						margin-start: 24;
-						margin-end: 24;
-
-						Gtk.Box {
-							styles ["linked"]
-
-							Gtk.Button {
-								styles ["osd", "circular"]
-								icon-name: "zoom-in-symbolic";
-
-								tooltip-text: _("Zoom In");
-
-								action-name: "detail.zoom-in";
-							}
-
-							Gtk.Button {
-								styles ["osd", "circular"]
-								icon-name: "zoom-out-symbolic";
-
-								tooltip-text: _("Zoom Out");
-
-								action-name: "detail.zoom-out";
-							}
+						Gtk.Spinner {
+							spinning: true;
+							height-request: 32;
+							width-request: 32;
 						}
 
-						Gtk.Button ext_screenshot_popin_button {
-							styles ["osd", "circular"]
-							icon-name: "pip-in-symbolic";
-
-							tooltip-text: _("Return to view");
+						Gtk.Label {
+							styles["title-1"]
+							label: _("Loading Details");
 						}
-					}
-
-					Adw.Bin {
-						styles ["tint"]
-
-						hexpand: true;
-						vexpand: true;
-
-						$ExmZoomPicture overlay_screenshot {}
-					}
+					};
 				}
 
-				Gtk.Stack stack {
-					vexpand: true;
+				Gtk.StackPage {
+					name: "page_error";
 
-					Gtk.StackPage {
-						name: "page_spinner";
+					child: Adw.StatusPage {
+						title: _("An Error Occurred");
+						icon-name: "dialog-question-symbolic";
+					};
+				}
 
-						child: Gtk.Box {
-							orientation: vertical;
-							spacing: 24;
-							valign: center;
+				Gtk.StackPage {
+					name: "page_detail";
+					child: Gtk.ScrolledWindow scroll_area {
+						Adw.Clamp {
+							maximum-size: 800;
 
-							Gtk.Spinner {
-								spinning: true;
-								height-request: 32;
-								width-request: 32;
-							}
+							Gtk.Box {
+								styles ["detail"]
+								orientation: vertical;
+								spacing: 24;
 
-							Gtk.Label {
-								styles["title-1"]
-								label: _("Loading Details");
-							}
-						};
-					}
-
-					Gtk.StackPage {
-						name: "page_error";
-
-						child: Adw.StatusPage {
-							title: _("An Error Occurred");
-							icon-name: "dialog-question-symbolic";
-						};
-					}
-
-					Gtk.StackPage {
-						name: "page_detail";
-						child: Gtk.ScrolledWindow scroll_area {
-							Adw.Clamp {
-								maximum-size: 800;
-
-								Gtk.Box {
-									styles ["detail"]
-									orientation: vertical;
+								Gtk.Box header {
+									orientation: horizontal;
 									spacing: 24;
 
-									Gtk.Box header {
+									Gtk.Image ext_icon {
+										halign: center;
+										valign: center;
+										pixel-size: 64;
+									}
+
+									Gtk.Box header_suffix {
 										orientation: horizontal;
 										spacing: 24;
 
-										Gtk.Image ext_icon {
-											halign: center;
+										Gtk.Box {
+											orientation: vertical;
+											hexpand: true;
 											valign: center;
-											pixel-size: 64;
+
+											Gtk.Label ext_title {
+												styles ["title-1"]
+												xalign: 0;
+												ellipsize: end;
+											}
+
+											Gtk.Label ext_author {
+												styles ["dim-label"]
+												label: "Author";
+												xalign: 0;
+												ellipsize: end;
+											}
 										}
 
-										Gtk.Box header_suffix {
-											orientation: horizontal;
-											spacing: 24;
-
-											Gtk.Box {
-												orientation: vertical;
-												hexpand: true;
-												valign: center;
-
-												Gtk.Label ext_title {
-													styles ["title-1"]
-													xalign: 0;
-													ellipsize: end;
-												}
-
-												Gtk.Label ext_author {
-													styles ["dim-label"]
-													label: "Author";
-													xalign: 0;
-													ellipsize: end;
-												}
-											}
-
-											$ExmInstallButton ext_install {
-												valign: center;
-												halign: center;
-											}
+										$ExmInstallButton ext_install {
+											valign: center;
+											halign: center;
 										}
 									}
+								}
 
-									Gtk.Overlay ext_screenshot_container {
-										[overlay]
-										Gtk.Button ext_screenshot_popout_button {
-											styles ["osd", "circular"]
-											icon-name: "pip-out-symbolic";
-											halign: end;
-											valign: end;
+								Gtk.Overlay ext_screenshot_container {
+									[overlay]
+									Gtk.Button ext_screenshot_popout_button {
+										styles ["osd", "circular"]
+										icon-name: "pip-out-symbolic";
+										halign: end;
+										valign: end;
 
-											margin-top: 8;
-											margin-bottom: 8;
-											margin-start: 8;
-											margin-end: 8;
+										margin-top: 8;
+										margin-bottom: 8;
+										margin-start: 8;
+										margin-end: 8;
 
-											tooltip-text: _("Enlarge image");
-										}
-
-										$ExmScreenshot ext_screenshot {}
+										tooltip-text: _("Enlarge image");
+										clicked => $screenshot_view_cb(template);
 									}
 
-									Gtk.Box {
-										orientation: vertical;
+									$ExmScreenshot ext_screenshot {}
+								}
 
-										Gtk.Label {
-											styles ["title-4", "detail-heading"]
+								Gtk.Box {
+									orientation: vertical;
 
-											label: _("Description");
-											xalign: 0;
-										}
+									Gtk.Label {
+										styles ["title-4", "detail-heading"]
 
-										Gtk.Label ext_description {
-											styles ["multiline"]
-											xalign: 0;
-											wrap: true;
-											wrap-mode: word_char;
-											selectable: true;
-										}
+										label: _("Description");
+										xalign: 0;
 									}
 
-									$ExmInfoBar ext_info_bar {}
+									Gtk.Label ext_description {
+										styles ["multiline"]
+										xalign: 0;
+										wrap: true;
+										wrap-mode: word_char;
+										selectable: true;
+									}
+								}
 
-									Gtk.Box {
-										orientation: vertical;
+								$ExmInfoBar ext_info_bar {}
 
-										Gtk.Label {
-											styles ["title-4", "detail-heading"]
+								Gtk.Box {
+									orientation: vertical;
 
-											label: _("Links");
-											xalign: 0;
-										}
+									Gtk.Label {
+										styles ["title-4", "detail-heading"]
 
-										Gtk.ListBox {
-											styles ["boxed-list"]
-
-											selection-mode: none;
-
-											Adw.ActionRow link_homepage {
-												[prefix]
-												Gtk.Image {
-													icon-name: "go-home-symbolic";
-												}
-
-												title: _("Homepage");
-												activatable: true;
-												action-name: "detail.open-homepage";
-
-												[suffix]
-												Gtk.Image {
-													styles ["dim-label"]
-													icon-name: "external-link-symbolic";
-												}
-											}
-
-											Adw.ActionRow link_extensions {
-												[prefix]
-												Gtk.Image {
-													icon-name: "web-browser-symbolic";
-												}
-
-												title: _("View on Extensions");
-												activatable: true;
-												action-name: "detail.open-extensions";
-
-												[suffix]
-												Gtk.Image {
-													styles ["dim-label"]
-													icon-name: "external-link-symbolic";
-												}
-											}
-										}
+										label: _("Links");
+										xalign: 0;
 									}
 
-									Gtk.Box {
-										orientation: vertical;
+									Gtk.ListBox {
+										styles ["boxed-list"]
 
-										Gtk.Label {
-											styles ["title-4", "detail-heading"]
+										selection-mode: none;
 
-											label: _("User Reviews");
-											xalign: 0;
+										Adw.ActionRow link_homepage {
+											[prefix]
+											Gtk.Image {
+												icon-name: "go-home-symbolic";
+											}
+
+											title: _("Homepage");
+											activatable: true;
+											action-name: "detail.open-homepage";
+
+											[suffix]
+											Gtk.Image {
+												styles ["dim-label"]
+												icon-name: "external-link-symbolic";
+											}
 										}
 
-										// TODO: Abstract into common class
-										Gtk.Stack comment_stack {
-											vexpand: true;
-
-											Gtk.StackPage {
-												name: "page_spinner";
-
-												child: Gtk.Image {
-													icon-name: "content-loading-symbolic";
-													icon-size: large;
-													valign: center;
-												};
+										Adw.ActionRow link_extensions {
+											[prefix]
+											Gtk.Image {
+												icon-name: "web-browser-symbolic";
 											}
 
-											Gtk.StackPage {
-												name: "page_error";
+											title: _("View on Extensions");
+											activatable: true;
+											action-name: "detail.open-extensions";
 
-												child: Adw.StatusPage {
-													title: _("An Error Occurred");
-													icon-name: "dialog-question-symbolic";
-												};
-											}
-
-											Gtk.StackPage {
-												name: "page_empty";
-
-												child: Gtk.Label {
-													label: _("There are no comments.");
-													valign: start;
-													xalign: 0;
-												};
-											}
-
-											Gtk.StackPage {
-												name: "page_comments";
-
-												child: Gtk.Box {
-													orientation: vertical;
-
-													Gtk.FlowBox comment_box {
-														max-children-per-line: 2;
-														homogeneous: true;
-														selection-mode: none;
-														row-spacing: 12;
-														column-spacing: 12;
-													}
-													Gtk.Button show_more_btn {
-														label: _("_Show All Reviews");
-														halign: center;
-														margin-top: 10;
-														use-underline: true;
-													}
-												};
+											[suffix]
+											Gtk.Image {
+												styles ["dim-label"]
+												icon-name: "external-link-symbolic";
 											}
 										}
 									}
 								}
+
+								Gtk.Box {
+									orientation: vertical;
+
+									Gtk.Label {
+										styles ["title-4", "detail-heading"]
+
+										label: _("User Reviews");
+										xalign: 0;
+									}
+
+									// TODO: Abstract into common class
+									Gtk.Stack comment_stack {
+										vexpand: true;
+
+										Gtk.StackPage {
+											name: "page_spinner";
+
+											child: Gtk.Image {
+												icon-name: "content-loading-symbolic";
+												icon-size: large;
+												valign: center;
+											};
+										}
+
+										Gtk.StackPage {
+											name: "page_error";
+
+											child: Adw.StatusPage {
+												title: _("An Error Occurred");
+												icon-name: "dialog-question-symbolic";
+											};
+										}
+
+										Gtk.StackPage {
+											name: "page_empty";
+
+											child: Gtk.Label {
+												label: _("There are no comments.");
+												valign: start;
+												xalign: 0;
+											};
+										}
+
+										Gtk.StackPage {
+											name: "page_comments";
+
+											child: Gtk.Box {
+												orientation: vertical;
+
+												Gtk.FlowBox comment_box {
+													max-children-per-line: 2;
+													homogeneous: true;
+													selection-mode: none;
+													row-spacing: 12;
+													column-spacing: 12;
+												}
+												Gtk.Button show_more_btn {
+													label: _("_Show All Reviews");
+													halign: center;
+													margin-top: 10;
+													use-underline: true;
+												}
+											};
+										}
+									}
+								}
 							}
-						};
-					}
+						}
+					};
 				}
 			}
 		};

--- a/src/exm-screenshot-view.blp
+++ b/src/exm-screenshot-view.blp
@@ -1,0 +1,67 @@
+using Gtk 4.0;
+using Adw 1;
+
+template $ExmScreenshotView: Adw.NavigationPage {
+  styles [
+    "tint"
+  ]
+
+  tag: "screenshot-view";
+
+  Adw.ToolbarView {
+    [top]
+    Adw.HeaderBar {}
+
+    content: Gtk.Overlay {
+      [overlay]
+      Gtk.Overlay image_overlay {
+        [overlay]
+        Gtk.Box {
+          orientation: horizontal;
+          spacing: 12;
+          halign: end;
+          valign: end;
+          margin-top: 18;
+          margin-bottom: 18;
+          margin-start: 18;
+          margin-end: 18;
+
+          Gtk.Button {
+            styles [
+              "osd",
+              "circular"
+            ]
+
+            icon-name: "zoom-out-symbolic";
+            tooltip-text: _("Zoom Out");
+            action-name: "screenshot.zoom-out";
+            height-request: 42;
+            width-request: 42;
+          }
+
+          Gtk.Button {
+            styles [
+              "osd",
+              "circular"
+            ]
+
+            icon-name: "zoom-in-symbolic";
+            tooltip-text: _("Zoom In");
+            action-name: "screenshot.zoom-in";
+            height-request: 42;
+            width-request: 42;
+          }
+        }
+
+        Adw.Bin {
+          hexpand: true;
+          vexpand: true;
+
+          $ExmZoomPicture overlay_screenshot {
+            notify::zoom-level => $notify_zoom();
+          }
+        }
+      }
+    };
+  }
+}

--- a/src/exm-screenshot-view.c
+++ b/src/exm-screenshot-view.c
@@ -1,0 +1,105 @@
+#include "exm-screenshot-view.h"
+
+#include "exm-zoom-picture.h"
+
+struct _ExmScreenshotView
+{
+    AdwNavigationPage parent_instance;
+
+    GSimpleAction *zoom_in;
+    GSimpleAction *zoom_out;
+    GSimpleAction *zoom_reset;
+
+    ExmZoomPicture *overlay_screenshot;
+};
+
+G_DEFINE_FINAL_TYPE (ExmScreenshotView, exm_screenshot_view, ADW_TYPE_NAVIGATION_PAGE)
+
+ExmScreenshotView *
+exm_screenshot_view_new (void)
+{
+    return g_object_new (EXM_TYPE_SCREENSHOT_VIEW, NULL);
+}
+
+static void
+exm_screenshot_view_finalize (GObject *object)
+{
+    ExmScreenshotView *self = (ExmScreenshotView *)object;
+
+    G_OBJECT_CLASS (exm_screenshot_view_parent_class)->finalize (object);
+}
+
+void
+exm_screenshot_view_set_screenshot (ExmScreenshotView *self,
+                                    GdkPaintable *paintable)
+{
+    exm_zoom_picture_set_paintable (self->overlay_screenshot, paintable);
+    exm_zoom_picture_set_zoom_level (self->overlay_screenshot, 1.0f);
+}
+
+static void
+notify_zoom (ExmZoomPicture    *picture,
+             GParamSpec        *pspec,
+             ExmScreenshotView *self)
+{
+    float zoom_level;
+    float max_zoom;
+    float min_zoom;
+
+    zoom_level = exm_zoom_picture_get_zoom_level (picture);
+    max_zoom = exm_zoom_picture_get_zoom_level_max (picture);
+    min_zoom = exm_zoom_picture_get_zoom_level_min (picture);
+
+    // Set action states
+    if (zoom_level < max_zoom)
+        g_simple_action_set_enabled (self->zoom_in, TRUE);
+    if (zoom_level == max_zoom)
+        g_simple_action_set_enabled (self->zoom_in, FALSE);
+    if (zoom_level > min_zoom)
+        g_simple_action_set_enabled (self->zoom_out, TRUE);
+    if (zoom_level == min_zoom)
+        g_simple_action_set_enabled (self->zoom_out, FALSE);
+}
+
+static void
+exm_screenshot_view_class_init (ExmScreenshotViewClass *klass)
+{
+    GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+    object_class->finalize = exm_screenshot_view_finalize;
+
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+
+    gtk_widget_class_set_template_from_resource (widget_class, "/com/mattjakeman/ExtensionManager/exm-screenshot-view.ui");
+
+    gtk_widget_class_bind_template_child (widget_class, ExmScreenshotView, overlay_screenshot);
+
+    gtk_widget_class_bind_template_callback (widget_class, notify_zoom);
+
+    gtk_widget_class_add_binding_action (widget_class, GDK_KEY_plus, GDK_CONTROL_MASK, "screenshot.zoom-in", NULL);
+    gtk_widget_class_add_binding_action (widget_class, GDK_KEY_minus, GDK_CONTROL_MASK, "screenshot.zoom-out", NULL);
+    gtk_widget_class_add_binding_action (widget_class, GDK_KEY_0, GDK_CONTROL_MASK, "screenshot.zoom-reset", NULL);
+}
+
+static void
+exm_screenshot_view_init (ExmScreenshotView *self)
+{
+    GSimpleActionGroup *group;
+
+    gtk_widget_init_template (GTK_WIDGET (self));
+
+    self->zoom_in = g_simple_action_new ("zoom-in", NULL);
+    g_signal_connect_swapped (self->zoom_in, "activate", G_CALLBACK (exm_zoom_picture_zoom_in), self->overlay_screenshot);
+
+    self->zoom_out = g_simple_action_new ("zoom-out", NULL);
+    g_signal_connect_swapped (self->zoom_out, "activate", G_CALLBACK (exm_zoom_picture_zoom_out), self->overlay_screenshot);
+
+    self->zoom_reset = g_simple_action_new ("zoom-reset", NULL);
+    g_signal_connect_swapped (self->zoom_reset, "activate", G_CALLBACK (exm_zoom_picture_zoom_reset), self->overlay_screenshot);
+
+    group = g_simple_action_group_new ();
+    g_action_map_add_action (G_ACTION_MAP (group), G_ACTION (self->zoom_in));
+    g_action_map_add_action (G_ACTION_MAP (group), G_ACTION (self->zoom_out));
+    g_action_map_add_action (G_ACTION_MAP (group), G_ACTION (self->zoom_reset));
+    gtk_widget_insert_action_group (GTK_WIDGET (self), "screenshot", G_ACTION_GROUP (group));
+}

--- a/src/exm-screenshot-view.h
+++ b/src/exm-screenshot-view.h
@@ -1,0 +1,18 @@
+# pragma once
+
+#include <adwaita.h>
+
+G_BEGIN_DECLS
+
+#define EXM_TYPE_SCREENSHOT_VIEW (exm_screenshot_view_get_type())
+
+G_DECLARE_FINAL_TYPE (ExmScreenshotView, exm_screenshot_view, EXM, SCREENSHOT_VIEW, AdwNavigationPage)
+
+ExmScreenshotView *
+exm_screenshot_view_new (void);
+
+void
+exm_screenshot_view_set_screenshot (ExmScreenshotView *self,
+                                    GdkPaintable      *paintable);
+
+G_END_DECLS

--- a/src/exm-window.blp
+++ b/src/exm-window.blp
@@ -75,6 +75,10 @@ template $ExmWindow : Adw.ApplicationWindow {
       }
 
       $ExmDetailView detail_view {}
+
+      $ExmScreenshotView screenshot_view {
+        title: bind detail_view.title;
+      }
     };
   }
 

--- a/src/exm.gresource.xml.in
+++ b/src/exm.gresource.xml.in
@@ -15,6 +15,7 @@
     <file>exm-error-dialog.ui</file>
     <file>exm-info-bar.ui</file>
     <file>exm-info-bar-item.ui</file>
+    <file>exm-screenshot-view.ui</file>
     <file alias="suggestions.txt">res/suggestions.txt</file>
     <file preprocess="xml-stripblanks" alias="com.mattjakeman.ExtensionManager.metainfo.xml">../data/@appstream_file@</file>
     <file>style.css</file>

--- a/src/meson.build
+++ b/src/meson.build
@@ -13,6 +13,9 @@ exm_sources = [
   'exm-info-bar.c',
   'exm-info-bar-item.c',
 
+  # Screenshot View
+  'exm-screenshot-view.c',
+
   # Installed Page
   'exm-installed-page.c',
   'exm-extension-row.c',
@@ -66,7 +69,8 @@ blueprints = custom_target('blueprints',
     'exm-upgrade-assistant.blp',
     'exm-error-dialog.blp',
     'exm-info-bar.blp',
-    'exm-info-bar-item.blp'
+    'exm-info-bar-item.blp',
+    'exm-screenshot-view.blp'
   ),
   output: '.',
   command: [find_program('blueprint-compiler'), 'batch-compile', '@OUTPUT@', '@CURRENT_SOURCE_DIR@', '@INPUT@'],

--- a/src/style.css
+++ b/src/style.css
@@ -15,7 +15,9 @@
 }
 
 .tint {
-	background-color: rgba(0,0,0,0.8);
+  /* Dark view_bg_color */
+  background-color: rgba(30, 30, 30, 1);
+  color: white;
 }
 
 .search-row {


### PR DESCRIPTION
Fixes

> - [ ] Pop the image back in from fullscreen

in #485