### PR TITLE
detail-view: Ensure extension title is correct

### DIFF
--- a/src/exm-detail-view.c
+++ b/src/exm-detail-view.c
@@ -443,6 +443,9 @@ exm_detail_view_load_for_uuid (ExmDetailView *self,
 
     self->uuid = uuid;
 
+    adw_window_title_set_title (self->title, NULL);
+    adw_window_title_set_subtitle (self->title, NULL);
+
     gtk_stack_set_visible_child_name (self->stack, "page_spinner");
     gtk_widget_set_visible (GTK_WIDGET (self->image_overlay), FALSE);
 


### PR DESCRIPTION
When viewing the details of an extension and it resulted in error, you could see the title of the extension seen just before.

Regression from #588