### PR TITLE
installed-page: Fix sharp bottom corners of placeholders

### DIFF
--- a/src/exm-installed-page.blp
+++ b/src/exm-installed-page.blp
@@ -43,7 +43,7 @@ template $ExmInstalledPage : Gtk.Widget {
 						}
 
 						Gtk.ListBox user_list_box {
-							styles ["boxed-list"]
+							styles ["boxed-list", "boxed-list-placeholder"]
 							valign: start;
 							selection-mode: none;
 						}
@@ -56,7 +56,7 @@ template $ExmInstalledPage : Gtk.Widget {
 						}
 
 						Gtk.ListBox system_list_box {
-							styles ["boxed-list"]
+							styles ["boxed-list", "boxed-list-placeholder"]
 							valign: start;
 							selection-mode: none;
 						}

--- a/src/style.css
+++ b/src/style.css
@@ -104,3 +104,17 @@ progressbar.success text {
     color: @green_1;
     opacity: 0.8;
 }
+
+/* Workaround for https://gitlab.gnome.org/GNOME/gtk/-/issues/5309 */
+.boxed-list-placeholder > row:nth-last-child(2),
+.boxed-list-placeholder > row.expander:nth-last-child(2):not(:checked) > box > list > row.header,
+.boxed-list-placeholder > row.expander:nth-last-child(2) > box > revealer > list.nested > row:last-child {
+    border-bottom: 0;
+    border-bottom-left-radius: 12px;
+    border-bottom-right-radius: 12px;
+}
+
+.boxed-list-placeholder > row.expander:nth-last-child(2) > box > revealer > list.nested {
+    border-bottom-left-radius: 12px;
+    border-bottom-right-radius: 12px;
+}


### PR DESCRIPTION
Workaround for https://gitlab.gnome.org/GNOME/gtk/-/issues/5309, the fix is from https://gitlab.gnome.org/GNOME/gtk/-/issues/5309#note_1692955

Fix https://github.com/mjakeman/extension-manager/issues/299