### PR TITLE
screenshot-view: Fix zoom shortcuts

### DIFF
--- a/src/exm-screenshot-view.blp
+++ b/src/exm-screenshot-view.blp
@@ -64,4 +64,23 @@ template $ExmScreenshotView: Adw.NavigationPage {
       }
     };
   }
+
+  Gtk.ShortcutController {
+    scope: managed;
+
+    Gtk.Shortcut {
+      trigger: "<Control>plus";
+      action: "action(screenshot.zoom-in)";
+    }
+
+    Gtk.Shortcut {
+      trigger: "<Control>minus";
+      action: "action(screenshot.zoom-out)";
+    }
+
+    Gtk.Shortcut {
+      trigger: "<Control>0";
+      action: "action(screenshot.zoom-reset)";
+    }
+  }
 }

--- a/src/exm-screenshot-view.c
+++ b/src/exm-screenshot-view.c
@@ -75,10 +75,6 @@ exm_screenshot_view_class_init (ExmScreenshotViewClass *klass)
     gtk_widget_class_bind_template_child (widget_class, ExmScreenshotView, overlay_screenshot);
 
     gtk_widget_class_bind_template_callback (widget_class, notify_zoom);
-
-    gtk_widget_class_add_binding_action (widget_class, GDK_KEY_plus, GDK_CONTROL_MASK, "screenshot.zoom-in", NULL);
-    gtk_widget_class_add_binding_action (widget_class, GDK_KEY_minus, GDK_CONTROL_MASK, "screenshot.zoom-out", NULL);
-    gtk_widget_class_add_binding_action (widget_class, GDK_KEY_0, GDK_CONTROL_MASK, "screenshot.zoom-reset", NULL);
 }
 
 static void


### PR DESCRIPTION
When zooming out to the minimum, keyboard shortcuts suddenly stop working.

Adding the shortcut to the widget_class does not work properly here, even thought the widget tree is mostly the same as detail-view.

Setting the scope property to `managed`, instead of `local` that behaves the same as it does now, does the job.