### PR TITLE
metainfo: Fix id

### DIFF
--- a/data/com.mattjakeman.ExtensionManager.metainfo.xml.in.in
+++ b/data/com.mattjakeman.ExtensionManager.metainfo.xml.in.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-	<id>@app_id@.desktop</id>
+	<id>@app_id@</id>
 	<metadata_license>CC0-1.0</metadata_license>
 	<project_license>GPL-3.0-or-later</project_license>
   <name>Extension Manager</name>


### PR DESCRIPTION
This should fix the app icon breakage in GNOME Software after the switch to libappstream on Flathub's side.