### PR TITLE
upgrade-assistant: Fix boxed list style

### DIFF
--- a/src/exm-upgrade-assistant.blp
+++ b/src/exm-upgrade-assistant.blp
@@ -106,7 +106,7 @@ template $ExmUpgradeAssistant : Adw.Dialog {
 								}
 
 								Gtk.ListBox user_list_box {
-									styles ["boxed-list"]
+									styles ["boxed-list", "boxed-list-placeholder"]
 									valign: start;
 									selection-mode: none;
 								}
@@ -119,7 +119,7 @@ template $ExmUpgradeAssistant : Adw.Dialog {
 								}
 
 								Gtk.ListBox system_list_box {
-									styles ["boxed-list"]
+									styles ["boxed-list", "boxed-list-placeholder"]
 									valign: start;
 									selection-mode: none;
 								}


### PR DESCRIPTION
Using the style applied to list boxes in installed-page. Missed in #598.