### PR TITLE
desktop: Update translators comment

### DIFF
--- a/data/com.mattjakeman.ExtensionManager.desktop.in.in
+++ b/data/com.mattjakeman.ExtensionManager.desktop.in.in
@@ -8,5 +8,5 @@ Categories=GTK;Utility
 StartupNotify=true
 MimeType=x-scheme-handler/gnome-extensions;
 Comment=Manage GNOME Shell Extensions
-# Translators: Do not translate
+# Translators: Search terms to find this application. Do NOT translate or localize the semicolons. The list MUST also end with a semicolon.
 Keywords=extension;manager;shell;

--- a/data/com.mattjakeman.ExtensionManager.desktop.in.in
+++ b/data/com.mattjakeman.ExtensionManager.desktop.in.in
@@ -9,5 +9,5 @@ StartupNotify=true
 MimeType=x-scheme-handler/gnome-extensions;
 Comment=Manage GNOME Shell Extensions
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons. The list MUST also end with a semicolon.
-# Make sure to leave the original strings and add your translations afterwords, so that users can search both in English and your language.
+# Make sure to leave the original strings and add your translations afterwards, so that users can search both in English and your language.
 Keywords=extension;manager;shell;

--- a/data/com.mattjakeman.ExtensionManager.desktop.in.in
+++ b/data/com.mattjakeman.ExtensionManager.desktop.in.in
@@ -9,4 +9,5 @@ StartupNotify=true
 MimeType=x-scheme-handler/gnome-extensions;
 Comment=Manage GNOME Shell Extensions
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons. The list MUST also end with a semicolon.
+# Make sure to leave the original strings and add your translations afterwords, so that users can search both in English and your language.
 Keywords=extension;manager;shell;


### PR DESCRIPTION
The value type of the Keywords key is localestring(s), so translators can translate this string:

https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html

However, they must keep the separator semicolons as it is, so explicit that instead.