### PR TITLE
backtrace: Define static functions only if `WITH_BACKTRACE`

### DIFF
--- a/src/exm-backtrace.c
+++ b/src/exm-backtrace.c
@@ -33,7 +33,6 @@
 #if WITH_BACKTRACE
 static struct backtrace_state *state = NULL;
 static int frames_omitted_count = 0;
-#endif
 
 static void
 exm_backtrace_error_cb (void       *data,
@@ -71,6 +70,7 @@ exm_backtrace_full_cb (GString    *string_builder,
 
     return 0;
 }
+#endif
 
 void
 exm_backtrace_init (char *filename)


### PR DESCRIPTION
The static functions are internal to file `exm-backtrace.c` and are only used to facilitate backtrace collection.  In build configurations with backtraces disabled (`meson setup -Dbacktrace=false`), `exm_backtrace_print()` will not call the static functions, so they are unused and thus need not be defined.

Previously, due to how the preprocessor macros were arranged, the static variables in this file would not be defined when backtraces are disabled; if any static functions use them, then builds with backtraces disabled would fail due to a compiler error like:

    ../extension-manager-0.5.1/src/exm-backtrace.c: In function ‘exm_backtrace_full_cb’:
    ../extension-manager-0.5.1/src/exm-backtrace.c:58:9: error: ‘frames_omitted_count’ undeclared (first use in this function)
       58 |         frames_omitted_count++;
          |

This commit fixes such errors when backtraces are disabled.

Fixes: dcc312e (Make libbacktrace an optional dependency, 2023-06-03)
Fixes: d63d301 (backtrace: Collate 'null' messages, 2024-04-01)