### PR TITLE
Add date to comment tiles

### DIFF
--- a/src/exm-comment-tile.blp
+++ b/src/exm-comment-tile.blp
@@ -1,8 +1,9 @@
 using Gtk 4.0;
-using Adw 1;
 
-template $ExmCommentTile : Gtk.Widget {
-  styles ["comment-tile"]
+template $ExmCommentTile: Gtk.Widget {
+  styles [
+    "comment-tile"
+  ]
 
   Gtk.Box {
     orientation: vertical;
@@ -11,14 +12,20 @@ template $ExmCommentTile : Gtk.Widget {
       orientation: horizontal;
 
       Gtk.Label author {
-        styles ["dim-label"]
+        styles [
+          "heading"
+        ]
+
         xalign: 0;
         label: bind template.comment as <$ExmComment>.author;
       }
 
       Gtk.Label author_badge {
-      	styles ["author-badge"]
-      	label: _("Author");
+        styles [
+          "author-badge"
+        ]
+
+        label: _("Author");
         visible: bind template.comment as <$ExmComment>.is_extension_creator;
       }
 
@@ -31,5 +38,14 @@ template $ExmCommentTile : Gtk.Widget {
     }
 
     $TextDisplay display {}
+
+    Gtk.Label date {
+      styles [
+        "dim-label"
+      ]
+
+      margin-top: 6;
+      xalign: 0;
+    }
   }
 }

--- a/src/exm-comment-tile.c
+++ b/src/exm-comment-tile.c
@@ -13,6 +13,7 @@ struct _ExmCommentTile
 
     GtkLabel *author;
     GtkLabel *author_badge;
+    GtkLabel *date;
     ExmRating *rating;
     TextDisplay *display;
 };
@@ -38,8 +39,6 @@ exm_comment_tile_new (ExmComment *comment)
 static void
 exm_comment_tile_finalize (GObject *object)
 {
-    ExmCommentTile *self = (ExmCommentTile *)object;
-
     G_OBJECT_CLASS (exm_comment_tile_parent_class)->finalize (object);
 }
 
@@ -87,15 +86,27 @@ exm_comment_tile_constructed (GObject *object)
     g_return_if_fail (EXM_IS_COMMENT (self->comment));
 
     TextFrame *frame;
+    GDateTime *datetime;
 
-    gchar *text;
+    gchar *text, *date;
     g_object_get (self->comment,
                   "comment", &text,
+                  "date", &date,
                   NULL);
 
     frame = format_parse_html (text);
+    g_free (text);
+
+    datetime = g_date_time_new_from_iso8601 (date, g_time_zone_new_utc ());
+    g_free (date);
 
     g_object_set (self->display, "frame", frame, NULL);
+
+    if (datetime != NULL)
+    {
+      gtk_label_set_label (self->date, g_date_time_format (datetime, "%x"));
+      g_date_time_unref (datetime);
+    }
 
     G_OBJECT_CLASS (exm_comment_tile_parent_class)->constructed (object);
 }
@@ -126,6 +137,7 @@ exm_comment_tile_class_init (ExmCommentTileClass *klass)
     gtk_widget_class_bind_template_child (widget_class, ExmCommentTile, display);
     gtk_widget_class_bind_template_child (widget_class, ExmCommentTile, author);
     gtk_widget_class_bind_template_child (widget_class, ExmCommentTile, author_badge);
+    gtk_widget_class_bind_template_child (widget_class, ExmCommentTile, date);
     gtk_widget_class_bind_template_child (widget_class, ExmCommentTile, rating);
 
     gtk_widget_class_set_layout_manager_type (widget_class, GTK_TYPE_BIN_LAYOUT);

--- a/src/web/model/exm-comment.c
+++ b/src/web/model/exm-comment.c
@@ -10,6 +10,7 @@ struct _ExmComment
     gchar *comment;
     gchar *author;
     int rating;
+    gchar *date;
 };
 
 static JsonSerializableIface *serializable_iface = NULL;
@@ -26,6 +27,7 @@ enum {
     PROP_COMMENT,
     PROP_AUTHOR,
     PROP_RATING,
+    PROP_DATE,
     N_PROPS
 };
 
@@ -67,6 +69,9 @@ exm_comment_get_property (GObject    *object,
     case PROP_RATING:
         g_value_set_int (value, self->rating);
         break;
+    case PROP_DATE:
+        g_value_set_string (value, self->date);
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
@@ -93,6 +98,9 @@ exm_comment_set_property (GObject      *object,
         break;
     case PROP_RATING:
         self->rating = g_value_get_int (value);
+        break;
+    case PROP_DATE:
+        self->date = g_value_dup_string (value);
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -136,6 +144,13 @@ exm_comment_class_init (ExmCommentClass *klass)
                           -1, 5, -1, /* min -1, max 5, default -1 */
                           G_PARAM_READWRITE);
 
+    properties [PROP_DATE] =
+        g_param_spec_string ("date",
+                             "Date",
+                             "Date",
+                             NULL,
+                             G_PARAM_READWRITE);
+
     g_object_class_install_properties (object_class, N_PROPS, properties);
 }
 
@@ -159,6 +174,14 @@ exm_comment_deserialize_property (JsonSerializable *serializable,
 
         obj = json_node_get_object (property_node);
         g_value_set_string (value, json_object_get_string_member (obj, "username"));
+        return TRUE;
+    }
+    else if (strcmp (property_name, "date") == 0)
+    {
+        JsonObject *obj;
+
+        obj = json_node_get_object (property_node);
+        g_value_set_string (value, json_object_get_string_member (obj, "timestamp"));
         return TRUE;
     }
 


### PR DESCRIPTION
Some changes I had in local from a few weeks ago. The layout may not be optimal.

Uses `%x` format:
> the preferred date representation for the current locale without the time

![image](https://github.com/mjakeman/extension-manager/assets/42654671/88e054d5-00b2-4efc-83d9-bed375d5e607)