### PR TITLE
Display info icon for Initialized/Inactive extension state

### DIFF
--- a/src/exm-extension-row.blp
+++ b/src/exm-extension-row.blp
@@ -74,6 +74,22 @@ template $ExmExtensionRow : Adw.ExpanderRow {
 		tooltip-text: _("A newer version of this extension is available");
 	}
 
+	[action]
+	Gtk.Image info_icon {
+		styles ["warning"]
+
+		icon-name: "dialog-information-symbolic";
+		valign: center;
+		halign: center;
+
+		margin-start: 9;
+		margin-end: 9;
+
+		visible: false;
+
+		tooltip-text: _("This extension could be activated in session modes such as the login screen or the lock screen");
+	}
+
 	Gtk.ListBoxRow {
 		activatable: false;
 

--- a/src/exm-extension-row.c
+++ b/src/exm-extension-row.c
@@ -146,6 +146,18 @@ unbind_extension (ExmExtensionRow *self)
     }
 }
 
+static const gchar *extension_state[] = {
+    [EXM_EXTENSION_STATE_ACTIVE] = "ACTIVE",
+    [EXM_EXTENSION_STATE_INACTIVE] = "INACTIVE",
+    [EXM_EXTENSION_STATE_ERROR] = "ERROR",
+    [EXM_EXTENSION_STATE_OUT_OF_DATE] = "OUT_OF_DATE",
+    [EXM_EXTENSION_STATE_DOWNLOADING] = "DOWNLOADING",
+    [EXM_EXTENSION_STATE_INITIALIZED] = "INITIALIZED",
+    [EXM_EXTENSION_STATE_DEACTIVATING] = "DEACTIVATING",
+    [EXM_EXTENSION_STATE_ACTIVATING] = "ACTIVATING",
+    [EXM_EXTENSION_STATE_UNINSTALLED] = "UNINSTALLED"
+};
+
 static void
 bind_extension (ExmExtensionRow *self,
                 ExmExtension    *extension)
@@ -222,6 +234,9 @@ bind_extension (ExmExtensionRow *self,
                                  NULL,
                                  NULL,
                                  NULL);
+
+    // set tooltip
+    gtk_widget_set_tooltip_text (self->ext_toggle, extension_state[state]);
 
     // Keep compatibility with GNOME Shell versions prior to 46
     if (gtk_switch_get_state (self->ext_toggle) != enabled &&

--- a/src/exm-extension-row.c
+++ b/src/exm-extension-row.c
@@ -27,6 +27,7 @@ struct _ExmExtensionRow
     GtkImage *update_icon;
     GtkImage *error_icon;
     GtkImage *out_of_date_icon;
+    GtkImage *info_icon;
 };
 
 G_DEFINE_FINAL_TYPE (ExmExtensionRow, exm_extension_row, ADW_TYPE_EXPANDER_ROW)
@@ -146,18 +147,6 @@ unbind_extension (ExmExtensionRow *self)
     }
 }
 
-static const gchar *extension_state[] = {
-    [EXM_EXTENSION_STATE_ACTIVE] = "ACTIVE",
-    [EXM_EXTENSION_STATE_INACTIVE] = "INACTIVE",
-    [EXM_EXTENSION_STATE_ERROR] = "ERROR",
-    [EXM_EXTENSION_STATE_OUT_OF_DATE] = "OUT_OF_DATE",
-    [EXM_EXTENSION_STATE_DOWNLOADING] = "DOWNLOADING",
-    [EXM_EXTENSION_STATE_INITIALIZED] = "INITIALIZED",
-    [EXM_EXTENSION_STATE_DEACTIVATING] = "DEACTIVATING",
-    [EXM_EXTENSION_STATE_ACTIVATING] = "ACTIVATING",
-    [EXM_EXTENSION_STATE_UNINSTALLED] = "UNINSTALLED"
-};
-
 static void
 bind_extension (ExmExtensionRow *self,
                 ExmExtension    *extension)
@@ -215,6 +204,11 @@ bind_extension (ExmExtensionRow *self,
     gtk_widget_set_visible (GTK_WIDGET (self->error_icon), state == EXM_EXTENSION_STATE_ERROR);
     gtk_widget_set_visible (GTK_WIDGET (self->out_of_date_icon), state == EXM_EXTENSION_STATE_OUT_OF_DATE);
 
+    gtk_widget_set_visible (GTK_WIDGET (self->info_icon),
+                            (state == EXM_EXTENSION_STATE_INITIALIZED
+                             || state == EXM_EXTENSION_STATE_INACTIVE)
+                             && enabled);
+
     gtk_actionable_set_action_target (GTK_ACTIONABLE (self->details_btn), "s", uuid);
 
     GAction *action;
@@ -234,9 +228,6 @@ bind_extension (ExmExtensionRow *self,
                                  NULL,
                                  NULL,
                                  NULL);
-
-    // set tooltip
-    gtk_widget_set_tooltip_text (self->ext_toggle, extension_state[state]);
 
     // Keep compatibility with GNOME Shell versions prior to 46
     if (gtk_switch_get_state (self->ext_toggle) != enabled &&
@@ -315,6 +306,7 @@ exm_extension_row_class_init (ExmExtensionRowClass *klass)
     gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, update_icon);
     gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, error_icon);
     gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, out_of_date_icon);
+    gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, info_icon);
 
     gtk_widget_class_bind_template_callback (widget_class, on_state_changed);
 }


### PR DESCRIPTION
## Updates
![image](https://github.com/mjakeman/extension-manager/assets/92677342/3583349e-84a7-4e12-ae35-910e2ad94773)
![image](https://github.com/mjakeman/extension-manager/assets/92677342/78c9cfa8-6a35-4430-9db0-5dd5094d242c)

## Related issues
https://github.com/mjakeman/extension-manager/issues/646
