### PR TITLE
app: Fix criticals in master runtime

### DIFF
--- a/src/exm-detail-view.c
+++ b/src/exm-detail-view.c
@@ -25,6 +25,8 @@
 #include "exm-info-bar.h"
 #include "exm-comment-tile.h"
 #include "exm-comment-dialog.h"
+#include "exm-install-button.h"
+#include "exm-screenshot.h"
 
 #include "web/exm-data-provider.h"
 #include "web/exm-image-resolver.h"
@@ -681,6 +683,10 @@ static void
 exm_detail_view_init (ExmDetailView *self)
 {
     GtkAdjustment *adj;
+
+    g_type_ensure (EXM_TYPE_INSTALL_BUTTON);
+    g_type_ensure (EXM_TYPE_SCREENSHOT);
+    g_type_ensure (EXM_TYPE_INFO_BAR);
 
     gtk_widget_init_template (GTK_WIDGET (self));
 

--- a/src/exm-info-bar.c
+++ b/src/exm-info-bar.c
@@ -103,5 +103,7 @@ exm_info_bar_class_init (ExmInfoBarClass *klass)
 static void
 exm_info_bar_init (ExmInfoBar *self)
 {
+    g_type_ensure (EXM_TYPE_INFO_BAR_ITEM);
+
     gtk_widget_init_template (GTK_WIDGET (self));
 }

--- a/src/exm-window.c
+++ b/src/exm-window.c
@@ -22,6 +22,7 @@
 #include "exm-browse-page.h"
 #include "exm-installed-page.h"
 #include "exm-detail-view.h"
+#include "exm-screenshot-view.h"
 #include "exm-upgrade-assistant.h"
 #include "exm-error-dialog.h"
 
@@ -397,6 +398,11 @@ do_version_check (ExmWindow *self)
 static void
 exm_window_init (ExmWindow *self)
 {
+    g_type_ensure (EXM_TYPE_INSTALLED_PAGE);
+    g_type_ensure (EXM_TYPE_BROWSE_PAGE);
+    g_type_ensure (EXM_TYPE_DETAIL_VIEW);
+    g_type_ensure (EXM_TYPE_SCREENSHOT_VIEW);
+
     gtk_widget_init_template (GTK_WIDGET (self));
 
     if (strstr (APP_ID, ".Devel") != NULL) {


### PR DESCRIPTION
Something has changed upstream that causes it to generate criticals and not work, not sure about the details but these changes make it work again using the development manifest.

See https://stackoverflow.com/questions/24235937/custom-gtk-widget-with-template-ui#comment53693581_29363948