### PR TITLE
local: Add support for version-name

### DIFF
--- a/src/exm-extension-row.c
+++ b/src/exm-extension-row.c
@@ -167,7 +167,7 @@ bind_extension (ExmExtensionRow *self,
     if (self->extension == NULL)
         return;
 
-    gchar *name, *uuid, *description, *version, *error_msg;
+    gchar *name, *uuid, *description, *version, *version_name, *error_msg;
     gboolean enabled, has_prefs, has_update, is_user;
     ExmExtensionState state;
     g_object_get (self->extension,
@@ -180,6 +180,7 @@ bind_extension (ExmExtensionRow *self,
                   "has-update", &has_update,
                   "is-user", &is_user,
                   "version", &version,
+                  "version-name", &version_name,
                   "error-msg", &error_msg,
                   NULL);
 
@@ -189,7 +190,8 @@ bind_extension (ExmExtensionRow *self,
     g_object_set (self->prefs_btn, "visible", has_prefs, NULL);
     g_object_set (self->remove_btn, "visible", is_user, NULL);
     g_object_set (self->update_icon, "visible", has_update, NULL);
-    g_object_set (self->version_label, "label", version, NULL);
+    g_object_set (self->version_label, "label", version_name ? g_strdup_printf ("%s (%s)", version_name, version)
+                                                             : version, NULL);
 
     // Trim description label's leading and trailing whitespace
     char *description_trimmed = g_strchomp (g_strstrip (description));

--- a/src/local/exm-extension.c
+++ b/src/local/exm-extension.c
@@ -16,6 +16,7 @@ struct _ExmExtension
     gboolean has_update;
     gboolean can_change;
     gchar *version;
+    gchar *version_name;
     gchar *error_msg;
 };
 
@@ -33,6 +34,7 @@ enum {
     PROP_HAS_UPDATE,
     PROP_CAN_CHANGE,
     PROP_VERSION,
+    PROP_VERSION_NAME,
     PROP_ERROR_MSG,
     N_PROPS
 };
@@ -95,6 +97,9 @@ exm_extension_get_property (GObject    *object,
     case PROP_VERSION:
         g_value_set_string (value, self->version);
         break;
+    case PROP_VERSION_NAME:
+        g_value_set_string (value, self->version_name);
+        break;
     case PROP_ERROR_MSG:
         g_value_set_string (value, self->error_msg);
         break;
@@ -146,6 +151,9 @@ exm_extension_set_property (GObject      *object,
         break;
     case PROP_VERSION:
         self->version = g_value_dup_string (value);
+        break;
+    case PROP_VERSION_NAME:
+        self->version_name = g_value_dup_string (value);
         break;
     case PROP_ERROR_MSG:
         self->error_msg = g_value_dup_string (value);
@@ -232,6 +240,13 @@ exm_extension_class_init (ExmExtensionClass *klass)
         g_param_spec_string ("version",
                              "Version",
                              "Version",
+                             NULL,
+                             G_PARAM_READWRITE);
+
+    properties [PROP_VERSION_NAME] =
+        g_param_spec_string ("version-name",
+                             "Version Name",
+                             "Version Name",
                              NULL,
                              G_PARAM_READWRITE);
 

--- a/src/local/exm-manager.c
+++ b/src/local/exm-manager.c
@@ -553,6 +553,7 @@ parse_single_extension (ExmExtension **extension,
     ExmExtensionState state;
     ExmExtensionType type;
     gchar *version = NULL;
+    gchar *version_name = NULL;
     gchar *error_msg = NULL;
 
     if (extension && *extension)
@@ -622,6 +623,10 @@ parse_single_extension (ExmExtension **extension,
             g_variant_get (prop_value, "d", &val);
             version = g_strdup_printf ("%d", (gint)val);
         }
+        else if (strcmp (prop_name, "version-name") == 0)
+        {
+            g_variant_get (prop_value, "s", &version_name);
+        }
         else if (strcmp (prop_name, "error") == 0)
         {
             g_variant_get (prop_value, "s", &error_msg);
@@ -641,12 +646,16 @@ parse_single_extension (ExmExtension **extension,
                   "has-update", has_update,
                   "can-change", can_change,
                   "version", version,
+                  "version_name", version_name,
                   "error-msg", error_msg,
                   NULL);
 
     g_free (uuid);
     g_free (display_name);
     g_free (description);
+    g_free (version);
+    g_free (version_name);
+    g_free (error_msg);
 }
 
 static void


### PR DESCRIPTION
If available, it will be displayed to the user along with the version field.

At the moment, it is only available for installed extensions. For remote ones, we have to switch to the new API.

Helps #515