### PR TITLE
git: Add pre-commit hook to format Blueprint files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: local
+    hooks:
+      - id: format-blueprint
+        name: Format Blueprint files
+        entry: blueprint-compiler format -f
+        language: system
+        files: \.blp$


### PR DESCRIPTION
Requires having `pre-commit` installed and run `pre-commit intall`.