### PR TITLE
Fix warnings when finalizing with remaining child widgets

### DIFF
--- a/src/exm-comment-tile.c
+++ b/src/exm-comment-tile.c
@@ -1,3 +1,23 @@
+/* exm-comment-tile.c
+ *
+ * Copyright 2022-2024 Matthew Jakeman <mjakeman26@outlook.co.nz>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include "exm-comment-tile.h"
 
 #include <text-engine/format/import.h>

--- a/src/exm-comment-tile.c
+++ b/src/exm-comment-tile.c
@@ -39,6 +39,12 @@ exm_comment_tile_new (ExmComment *comment)
 static void
 exm_comment_tile_finalize (GObject *object)
 {
+    GtkWidget *child;
+    ExmCommentTile *self = (ExmCommentTile *)object;
+
+    child = gtk_widget_get_first_child (GTK_WIDGET (self));
+    gtk_widget_unparent (child);
+
     G_OBJECT_CLASS (exm_comment_tile_parent_class)->finalize (object);
 }
 

--- a/src/exm-rating.c
+++ b/src/exm-rating.c
@@ -1,3 +1,23 @@
+/* exm-rating.c
+ *
+ * Copyright 2022-2024 Matthew Jakeman <mjakeman26@outlook.co.nz>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include "exm-rating.h"
 
 #include <glib/gi18n.h>

--- a/src/exm-rating.c
+++ b/src/exm-rating.c
@@ -34,7 +34,11 @@ exm_rating_new (void)
 static void
 exm_rating_finalize (GObject *object)
 {
+    GtkWidget *child;
     ExmRating *self = (ExmRating *)object;
+
+    child = gtk_widget_get_first_child (GTK_WIDGET (self));
+    gtk_widget_unparent (child);
 
     G_OBJECT_CLASS (exm_rating_parent_class)->finalize (object);
 }


### PR DESCRIPTION
The code is copied from other widgets such as `ExmBrowsePage` or `ExmCommentDialog` among others. The warnings can be observed (without these changes) when opening and closing the detail view.