### PR TITLE
Simple HTML viewer

### DIFF
--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -27,8 +27,7 @@ jobs:
         run: |
           apt update
           apt install -y git meson gcc gettext cmake appstream desktop-file-utils \
-            libadwaita-1-dev libgtk-4-dev libjson-glib-dev libsoup-3.0-dev libtext-engine-dev \
-            blueprint-compiler
+            libadwaita-1-dev libgtk-4-dev libjson-glib-dev libsoup-3.0-dev blueprint-compiler
 
       - name: Setup Repository
         run: |

--- a/README.md
+++ b/README.md
@@ -107,17 +107,17 @@ Extension Manager depends on the following libraries:
  - libadwaita
  - libjson-glib
  - libsoup
+ - libxml2
  - [blueprint](https://gitlab.gnome.org/jwestman/blueprint-compiler)
- - [text-engine](https://github.com/mjakeman/text-engine/)
 
 On Debian-based distributions, the required dependencies can be installed with the following command:
 ```shell
-sudo apt install blueprint-compiler gettext libadwaita-1-dev libgtk-4-dev libjson-glib-dev libsoup-3.0-dev libtext-engine-dev meson
+sudo apt install blueprint-compiler gettext libadwaita-1-dev libgtk-4-dev libjson-glib-dev libsoup-3.0-dev libxml2-dev meson
 ```
 
 ### Building From Source
 ```shell
 meson setup _build
-ninja -C _build
-ninja install -C _build
+meson compile -C _build
+meson install -C _build
 ```

--- a/build-aux/com.mattjakeman.ExtensionManager.Devel.json
+++ b/build-aux/com.mattjakeman.ExtensionManager.Devel.json
@@ -55,21 +55,6 @@
             ]
         },
         {
-            "name" : "text-engine",
-            "builddir" : true,
-            "buildsystem" : "meson",
-            "config-opts" : [
-                "--libdir=/app/lib"
-            ],
-            "sources" : [
-                {
-                    "type" : "git",
-                    "url" : "https://github.com/mjakeman/text-engine.git",
-                    "branch" : "master"
-                }
-            ]
-        },
-        {
             "name" : "extension-manager",
             "builddir" : true,
             "buildsystem" : "meson",

--- a/build-aux/com.mattjakeman.ExtensionManager.json
+++ b/build-aux/com.mattjakeman.ExtensionManager.json
@@ -54,21 +54,6 @@
             ]
         },
         {
-            "name" : "text-engine",
-            "builddir" : true,
-            "buildsystem" : "meson",
-            "config-opts" : [
-                "--libdir=/app/lib"
-            ],
-            "sources" : [
-                {
-                    "type" : "git",
-                    "url" : "https://github.com/mjakeman/text-engine.git",
-                    "branch" : "master"
-                }
-            ]
-        },
-        {
             "name" : "extension-manager",
             "builddir" : true,
             "buildsystem" : "meson",

--- a/src/exm-application.c
+++ b/src/exm-application.c
@@ -42,14 +42,6 @@ exm_application_new (gchar *application_id,
                        NULL);
 }
 
-static void
-exm_application_finalize (GObject *object)
-{
-    ExmApplication *self = (ExmApplication *)object;
-
-    G_OBJECT_CLASS (exm_application_parent_class)->finalize (object);
-}
-
 static ExmWindow *
 get_current_window (GApplication *app)
 {
@@ -156,8 +148,6 @@ exm_application_class_init (ExmApplicationClass *klass)
     GObjectClass *object_class = G_OBJECT_CLASS (klass);
     GApplicationClass *app_class = G_APPLICATION_CLASS (klass);
 
-    object_class->finalize = exm_application_finalize;
-
     /*
     * We connect to the activate callback to create a window when the application
     * has been launched. Additionally, this callback notifies us when the user
@@ -191,13 +181,6 @@ exm_application_show_about (GSimpleAction *action,
     adw_about_dialog_set_developers (ADW_ABOUT_DIALOG (about_dialog), authors);
     adw_about_dialog_set_translator_credits (ADW_ABOUT_DIALOG (about_dialog), _("translator-credits"));
     adw_about_dialog_set_copyright (ADW_ABOUT_DIALOG (about_dialog), "© 2022 Matthew Jakeman");
-
-    // Dependency Attribution
-    adw_about_dialog_add_legal_section (ADW_ABOUT_DIALOG (about_dialog),
-                                        "text-engine",
-                                        "Copyright (C) 2022 Matthew Jakeman",
-                                        GTK_LICENSE_MPL_2_0,
-                                        NULL);
 
 #if WITH_BACKTRACE
     adw_about_dialog_add_legal_section (ADW_ABOUT_DIALOG (about_dialog),

--- a/src/exm-application.c
+++ b/src/exm-application.c
@@ -1,6 +1,6 @@
 /* exm-application.c
  *
- * Copyright 2022 Matthew Jakeman
+ * Copyright 2022-2024 Matthew Jakeman <mjakeman26@outlook.co.nz>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,6 +14,8 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 #include "exm-config.h"
@@ -180,19 +182,19 @@ exm_application_show_about (GSimpleAction *action,
     adw_about_dialog_set_comments (ADW_ABOUT_DIALOG (about_dialog), _("Browse, install, and manage GNOME Shell Extensions."));
     adw_about_dialog_set_developers (ADW_ABOUT_DIALOG (about_dialog), authors);
     adw_about_dialog_set_translator_credits (ADW_ABOUT_DIALOG (about_dialog), _("translator-credits"));
-    adw_about_dialog_set_copyright (ADW_ABOUT_DIALOG (about_dialog), "© 2022 Matthew Jakeman");
+    adw_about_dialog_set_copyright (ADW_ABOUT_DIALOG (about_dialog), "© 2022-2024 Matthew Jakeman");
 
 #if WITH_BACKTRACE
     adw_about_dialog_add_legal_section (ADW_ABOUT_DIALOG (about_dialog),
                                         "libbacktrace",
-                                        "Copyright (C) 2012-2016 Free Software Foundation, Inc.",
+                                        "© 2012-2016 Free Software Foundation, Inc.",
                                         GTK_LICENSE_BSD_3,
                                         NULL);
 #endif
 
     adw_about_dialog_add_legal_section (ADW_ABOUT_DIALOG (about_dialog),
                                         "blueprint",
-                                        "Copyright (C) 2021 James Westman",
+                                        "© 2021 James Westman",
                                         GTK_LICENSE_LGPL_3_0,
                                         NULL);
 

--- a/src/exm-comment-tile.blp
+++ b/src/exm-comment-tile.blp
@@ -37,7 +37,13 @@ template $ExmCommentTile: Gtk.Widget {
       }
     }
 
-    $TextDisplay display {}
+    Gtk.Label {
+      styles [
+        "multiline"
+      ]
+
+      label: bind template.comment as <$ExmComment>.comment;
+    }
 
     Gtk.Label date {
       styles [

--- a/src/exm-comment-tile.blp
+++ b/src/exm-comment-tile.blp
@@ -43,6 +43,11 @@ template $ExmCommentTile: Gtk.Widget {
       ]
 
       label: bind template.comment as <$ExmComment>.comment;
+      margin-top: 6;
+      use-markup: true;
+      wrap: true;
+      wrap-mode: word_char;
+      xalign: 0;
     }
 
     Gtk.Label date {

--- a/src/exm-comment-tile.c
+++ b/src/exm-comment-tile.c
@@ -20,9 +20,6 @@
 
 #include "exm-comment-tile.h"
 
-#include <text-engine/format/import.h>
-#include <text-engine/ui/display.h>
-
 #include "exm-rating.h"
 
 struct _ExmCommentTile
@@ -33,9 +30,8 @@ struct _ExmCommentTile
 
     GtkLabel *author;
     GtkLabel *author_badge;
-    GtkLabel *date;
     ExmRating *rating;
-    TextDisplay *display;
+    GtkLabel *date;
 };
 
 G_DEFINE_FINAL_TYPE (ExmCommentTile, exm_comment_tile, GTK_TYPE_WIDGET)
@@ -111,23 +107,15 @@ exm_comment_tile_constructed (GObject *object)
 
     g_return_if_fail (EXM_IS_COMMENT (self->comment));
 
-    TextDocument *document;
     GDateTime *datetime;
 
-    gchar *text, *date;
+    gchar *date;
     g_object_get (self->comment,
-                  "comment", &text,
                   "date", &date,
                   NULL);
 
-    document = text_document_new ();
-    document->frame = format_parse_html (text);
-    g_free (text);
-
     datetime = g_date_time_new_from_iso8601 (date, g_time_zone_new_utc ());
     g_free (date);
-
-    g_object_set (self->display, "document", document, NULL);
 
     if (datetime != NULL)
     {
@@ -161,11 +149,10 @@ exm_comment_tile_class_init (ExmCommentTileClass *klass)
 
     gtk_widget_class_set_template_from_resource (widget_class, "/com/mattjakeman/ExtensionManager/exm-comment-tile.ui");
 
-    gtk_widget_class_bind_template_child (widget_class, ExmCommentTile, display);
     gtk_widget_class_bind_template_child (widget_class, ExmCommentTile, author);
     gtk_widget_class_bind_template_child (widget_class, ExmCommentTile, author_badge);
-    gtk_widget_class_bind_template_child (widget_class, ExmCommentTile, date);
     gtk_widget_class_bind_template_child (widget_class, ExmCommentTile, rating);
+    gtk_widget_class_bind_template_child (widget_class, ExmCommentTile, date);
 
     gtk_widget_class_set_layout_manager_type (widget_class, GTK_TYPE_BIN_LAYOUT);
 }

--- a/src/exm-detail-view.blp
+++ b/src/exm-detail-view.blp
@@ -20,6 +20,7 @@ template $ExmDetailView: Adw.NavigationPage {
           header_suffix.orientation: vertical;
           header_suffix.spacing: 12;
           ext_install.halign: start;
+          comment_box.min-children-per-line: 1;
         }
 
         apply => $breakpoint_apply_cb() swapped;
@@ -304,6 +305,7 @@ template $ExmDetailView: Adw.NavigationPage {
                         orientation: vertical;
 
                         Gtk.FlowBox comment_box {
+                          min-children-per-line: 2;
                           max-children-per-line: 2;
                           homogeneous: true;
                           selection-mode: none;

--- a/src/exm-utils.c
+++ b/src/exm-utils.c
@@ -1,6 +1,6 @@
 /* exm-utils.c
  *
- * Copyright 2022 Matthew Jakeman <mjakeman26@outlook.co.nz>
+ * Copyright 2022-2024 Matthew Jakeman <mjakeman26@outlook.co.nz>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/exm-utils.h
+++ b/src/exm-utils.h
@@ -24,3 +24,6 @@
 
 char *
 exm_utils_read_resource (const char *resource, gsize *length);
+
+gchar *
+exm_utils_convert_html (const gchar *html);

--- a/src/exm-utils.h
+++ b/src/exm-utils.h
@@ -1,6 +1,6 @@
 /* exm-utils.h
  *
- * Copyright 2022 Matthew Jakeman <mjakeman26@outlook.co.nz>
+ * Copyright 2022-2024 Matthew Jakeman <mjakeman26@outlook.co.nz>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/meson.build
+++ b/src/meson.build
@@ -40,8 +40,7 @@ exm_deps = [
   dependency('libadwaita-1'),
   dependency('gio-unix-2.0'),
   dependency('json-glib-1.0'),
-  dependency('libsoup-3.0'),
-  dependency('text-engine-0.1')
+  dependency('libsoup-3.0')
 ]
 
 if libbacktrace_dep.found()

--- a/src/meson.build
+++ b/src/meson.build
@@ -40,7 +40,8 @@ exm_deps = [
   dependency('libadwaita-1'),
   dependency('gio-unix-2.0'),
   dependency('json-glib-1.0'),
-  dependency('libsoup-3.0')
+  dependency('libsoup-3.0'),
+  dependency('libxml-2.0'),
 ]
 
 if libbacktrace_dep.found()

--- a/src/web/model/exm-comment.c
+++ b/src/web/model/exm-comment.c
@@ -1,5 +1,7 @@
 #include "exm-comment.h"
 
+#include "exm-utils.h"
+
 #include <json-glib/json-glib.h>
 
 struct _ExmComment
@@ -40,14 +42,6 @@ exm_comment_new (void)
 }
 
 static void
-exm_comment_finalize (GObject *object)
-{
-    ExmComment *self = (ExmComment *)object;
-
-    G_OBJECT_CLASS (exm_comment_parent_class)->finalize (object);
-}
-
-static void
 exm_comment_get_property (GObject    *object,
                           guint       prop_id,
                           GValue     *value,
@@ -61,7 +55,7 @@ exm_comment_get_property (GObject    *object,
         g_value_set_boolean (value, self->is_extension_creator);
         break;
     case PROP_COMMENT:
-        g_value_set_string (value, self->comment);
+        g_value_set_string (value, exm_utils_convert_html (self->comment));
         break;
     case PROP_AUTHOR:
         g_value_set_string (value, self->author);
@@ -112,7 +106,6 @@ exm_comment_class_init (ExmCommentClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS (klass);
 
-    object_class->finalize = exm_comment_finalize;
     object_class->get_property = exm_comment_get_property;
     object_class->set_property = exm_comment_set_property;
 

--- a/src/web/model/exm-comment.c
+++ b/src/web/model/exm-comment.c
@@ -1,3 +1,23 @@
+/* exm-comment.c
+ *
+ * Copyright 2022-2024 Matthew Jakeman <mjakeman26@outlook.co.nz>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include "exm-comment.h"
 
 #include "exm-utils.h"


### PR DESCRIPTION
As mentioned in https://github.com/mjakeman/text-engine/issues/40#issuecomment-2352937530. The code is adapted from the `import-html` source file of text-engine, drops its dependency and makes us depend on libxml2 which is in GNOME SDK.

Close #163
Close #687