### PR TITLE
general: Handle not found errors with empty page

### DIFF
--- a/src/exm-comment-dialog.c
+++ b/src/exm-comment-dialog.c
@@ -157,7 +157,7 @@ on_get_comments (GObject          *source,
 
     GListModel *model = exm_comment_provider_get_comments_finish (EXM_COMMENT_PROVIDER (source), res, &error);
 
-    if (error)
+    if (error && error->code != 404)
     {
         // Filter 5xx status codes (server errors)
         if (error->code / 100 == 5)

--- a/src/exm-detail-view.c
+++ b/src/exm-detail-view.c
@@ -367,7 +367,7 @@ on_data_loaded (GObject      *source,
     data = exm_data_provider_get_finish (EXM_DATA_PROVIDER (source), result, &error);
     self = EXM_DETAIL_VIEW (user_data);
 
-    if (error)
+    if (error && error->code != 404)
     {
         // Filter 5xx status codes (server errors)
         if (error->code / 100 == 5)

--- a/src/exm-upgrade-assistant.c
+++ b/src/exm-upgrade-assistant.c
@@ -366,7 +366,7 @@ on_extension_processed (GObject      *source,
     data = (ExtensionCheckData *) user_data;
     self = EXM_UPGRADE_ASSISTANT (data->assistant);
 
-    if (error)
+    if (error && error->code != 404)
     {
         // Filter 5xx status codes (server errors)
         if (error->code / 100 == 5)


### PR DESCRIPTION
Overlooked in https://github.com/mjakeman/extension-manager/pull/729 and required to handle extensions that are not hosted on the Extensions website.

Not needed for browse page as it checks the size of the results list.