### PR TITLE
general: Use AdwSpinnerPaintable where possible

### DIFF
--- a/src/exm-comment-dialog.blp
+++ b/src/exm-comment-dialog.blp
@@ -1,6 +1,10 @@
 using Gtk 4.0;
 using Adw 1;
 
+Adw.SpinnerPaintable spinner {
+  widget: loading_status;
+}
+
 template $ExmCommentDialog: Adw.Dialog {
   content-width: 600;
   content-height: 600;
@@ -12,59 +16,39 @@ template $ExmCommentDialog: Adw.Dialog {
     [top]
     Adw.HeaderBar {}
 
-    content: Gtk.ScrolledWindow {
-      Adw.Clamp {
-        Gtk.Stack stack {
-          vexpand: true;
+    content: Gtk.Stack stack {
+      Gtk.StackPage {
+        name: "page_spinner";
 
-          Gtk.StackPage {
-            name: "page_spinner";
+        child: Adw.StatusPage loading_status {
+          paintable: spinner;
+          title: _("Loading Comments");
+        };
+      }
 
-            child: Gtk.Box {
-              orientation: vertical;
-              spacing: 12;
-              valign: center;
+      Gtk.StackPage {
+        name: "page_error";
 
-              Adw.Spinner {
-                halign: center;
-                valign: center;
-                height-request: 32;
-                width-request: 32;
-              }
+        child: Adw.StatusPage error_status {
+          icon-name: "offline-symbolic";
+          title: _("Connection Error");
+        };
+      }
 
-              Gtk.Label {
-                styles [
-                  "title-2"
-                ]
+      Gtk.StackPage {
+        name: "page_comments";
 
-                label: _("Loading Comments");
-              }
-            };
-          }
-
-          Gtk.StackPage {
-            name: "page_error";
-
-            child: Adw.StatusPage error_status {
-              icon-name: "offline-symbolic";
-              title: _("Connection Error");
-            };
-          }
-
-          Gtk.StackPage {
-            name: "page_comments";
-
-            child: Gtk.ListBox list_box {
+        child: Adw.PreferencesPage {
+          Adw.PreferencesGroup {
+            Gtk.ListBox list_box {
               styles [
-                "content",
                 "boxed-list"
               ]
 
-              valign: start;
               selection-mode: none;
-            };
+            }
           }
-        }
+        };
       }
     };
   };

--- a/src/exm-detail-view.blp
+++ b/src/exm-detail-view.blp
@@ -1,6 +1,10 @@
 using Gtk 4.0;
 using Adw 1;
 
+Adw.SpinnerPaintable spinner {
+  widget: loading_status;
+}
+
 template $ExmDetailView: Adw.NavigationPage {
   Adw.ToolbarView {
     [top]
@@ -33,30 +37,9 @@ template $ExmDetailView: Adw.NavigationPage {
         Gtk.StackPage {
           name: "page_spinner";
 
-          child: Gtk.Box {
-            orientation: vertical;
-            spacing: 24;
-            valign: center;
-
-            Adw.Spinner {
-              focusable: true;
-              halign: center;
-              valign: center;
-              height-request: 32;
-              width-request: 32;
-
-              accessibility {
-                labelled-by: loading_details;
-              }
-            }
-
-            Gtk.Label loading_details {
-              styles [
-                "title-1"
-              ]
-
-              label: _("Loading Details");
-            }
+          child: Adw.StatusPage loading_status {
+            paintable: spinner;
+            title: _("Loading Details");
           };
         }
 

--- a/src/exm-upgrade-assistant.blp
+++ b/src/exm-upgrade-assistant.blp
@@ -1,6 +1,10 @@
 using Gtk 4.0;
 using Adw 1;
 
+Adw.SpinnerPaintable spinner {
+  widget: counter;
+}
+
 template $ExmUpgradeAssistant: Adw.Dialog {
   content-width: 400;
   content-height: 600;
@@ -67,24 +71,8 @@ template $ExmUpgradeAssistant: Adw.Dialog {
       Gtk.StackPage waiting {
         name: "waiting";
 
-        child: Gtk.Box {
-          orientation: vertical;
-          spacing: 12;
-          valign: center;
-
-          Adw.Spinner {
-            focusable: true;
-            halign: center;
-            valign: center;
-            height-request: 32;
-            width-request: 32;
-          }
-
-          Gtk.Label counter {
-            styles [
-              "title-2"
-            ]
-          }
+        child: Adw.StatusPage counter {
+          paintable: spinner;
         };
       }
 

--- a/src/exm-upgrade-assistant.c
+++ b/src/exm-upgrade-assistant.c
@@ -1,6 +1,7 @@
-/* exm-upgrade-assistant.c
+/*
+ * exm-upgrade-assistant.c
  *
- * Copyright 2022-2024 Matthew Jakeman <mjakeman26@outlook.co.nz>
+ * Copyright 2022-2025 Matthew Jakeman <mjakeman26@outlook.co.nz>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -57,7 +58,7 @@ struct _ExmUpgradeAssistant
     GtkLabel *description;
 
     // Waiting Page
-    GtkLabel *counter;
+    AdwStatusPage *counter;
 
     // Error Page
     AdwStatusPage *error_status;
@@ -173,7 +174,7 @@ update_checked_count (ExmUpgradeAssistant *self)
                             self->number_checked,
                             self->total_extensions);
 
-    gtk_label_set_text (self->counter, text);
+    adw_status_page_set_title (self->counter, text);
     g_free (text);
 }
 


### PR DESCRIPTION
- Replaces boxes with status pages, thus enabling their use and simplifying widget trees.

- Declares the spinners first in the blueprints to prevent a Gtk warning about unloadable images. This warning occurs when the widgets are directly declared in the AdwStatusPage property.