### PR TITLE
comment-dialog: Fix crash on close while loading

### DIFF
--- a/build-aux/com.mattjakeman.ExtensionManager.Devel.json
+++ b/build-aux/com.mattjakeman.ExtensionManager.Devel.json
@@ -37,8 +37,8 @@
                 {
                     "type" : "git",
                     "url" : "https://gitlab.gnome.org/jwestman/blueprint-compiler.git",
-                    "commit" : "8e10fcf8692108b9d4ab78f41086c5d7773ef864",
-                    "tag" : "v0.14.0"
+                    "commit" : "04ef0944db56ab01307a29aaa7303df6067cb3c0",
+                    "tag" : "v0.16.0"
                 }
             ]
         },

--- a/build-aux/com.mattjakeman.ExtensionManager.json
+++ b/build-aux/com.mattjakeman.ExtensionManager.json
@@ -36,8 +36,8 @@
                 {
                     "type" : "git",
                     "url" : "https://gitlab.gnome.org/jwestman/blueprint-compiler.git",
-                    "commit" : "8e10fcf8692108b9d4ab78f41086c5d7773ef864",
-                    "tag" : "v0.14.0"
+                    "commit" : "04ef0944db56ab01307a29aaa7303df6067cb3c0",
+                    "tag" : "v0.16.0"
                 }
             ]
         },
@@ -70,8 +70,8 @@
                 {
                     "type" : "git",
                     "url" : "https://github.com/mjakeman/extension-manager",
-                    "commit" : "62f3759e10cfd21014c805dc75645947569d48a9",
-                    "tag" : "v0.6.0"
+                    "commit" : "54585fc15c3fe4939f2ba22ebc8808e6ef46c8f4",
+                    "tag" : "v0.6.1"
                 }
             ]
         }


### PR DESCRIPTION
Partially reverts a389ff389ad09f8bc13f77140e890166ea53d9fc which was mostly a workaround and uses GObject's dispose to cancel the ongoing request if the dialog is closed before it is completed.

Fix https://github.com/mjakeman/extension-manager/issues/310