### PR TITLE
extension-row: Use AdwActionRow for description

### DIFF
--- a/src/exm-extension-row.blp
+++ b/src/exm-extension-row.blp
@@ -90,110 +90,29 @@ template $ExmExtensionRow: Adw.ExpanderRow {
     tooltip-text: _("This extension could be activated in session modes such as the login screen or the lock screen");
   }
 
-  Gtk.ListBoxRow {
-    activatable: false;
+  Adw.ActionRow description_row {
+    styles [
+      "multiline",
+      "property"
+    ]
 
-    Gtk.Grid {
-      styles [
-        "row-content"
-      ]
+    title: _("Description");
+  }
 
-      row-spacing: 15;
-      column-spacing: 15;
+  Adw.ActionRow version_row {
+    styles [
+      "property"
+    ]
 
-      Gtk.Label description_title {
-        styles [
-          "dim-label"
-        ]
+    title: _("Version");
+  }
 
-        label: _("Description");
-        xalign: 0;
-        yalign: 0;
+  Adw.ActionRow error_row {
+    styles [
+      "property"
+    ]
 
-        layout {
-          row: 0;
-          column: 0;
-        }
-      }
-
-      Gtk.Label description_label {
-        styles [
-          "multiline"
-        ]
-
-        xalign: 0;
-        wrap-mode: word;
-        wrap: true;
-        selectable: true;
-
-        layout {
-          row: 0;
-          column: 1;
-        }
-
-        accessibility {
-          labelled-by: description_title;
-        }
-      }
-
-      Gtk.Label version_title {
-        styles [
-          "dim-label"
-        ]
-
-        label: _("Version");
-        xalign: 0;
-        yalign: 0;
-
-        layout {
-          row: 1;
-          column: 0;
-        }
-      }
-
-      Gtk.Label version_label {
-        xalign: 0;
-        wrap-mode: word;
-        wrap: true;
-        selectable: true;
-
-        layout {
-          row: 1;
-          column: 1;
-        }
-
-        accessibility {
-          labelled-by: version_title;
-        }
-      }
-
-      Gtk.Label error_label_tag {
-        styles [
-          "dim-label"
-        ]
-
-        label: _("Error");
-        xalign: 0;
-        yalign: 0;
-
-        layout {
-          row: 2;
-          column: 0;
-        }
-      }
-
-      Gtk.Label error_label {
-        xalign: 0;
-        wrap-mode: word_char;
-        wrap: true;
-        selectable: true;
-
-        layout {
-          row: 2;
-          column: 1;
-        }
-      }
-    }
+    title: _("Error");
   }
 
   Gtk.ListBoxRow {

--- a/src/exm-extension-row.c
+++ b/src/exm-extension-row.c
@@ -42,11 +42,9 @@ struct _ExmExtensionRow
     GtkButton *details_btn;
     GtkSwitch *ext_toggle;
 
-    GtkLabel *description_label;
-    GtkLabel *version_title;
-    GtkLabel *version_label;
-    GtkLabel *error_label;
-    GtkLabel *error_label_tag;
+    AdwActionRow *description_row;
+    AdwActionRow *version_row;
+    AdwActionRow *error_row;
 
     GtkImage *update_icon;
     GtkImage *error_icon;
@@ -134,14 +132,6 @@ exm_extension_row_set_property (GObject      *object,
     }
 }
 
-static void
-set_error_label_visible (ExmExtensionRow *self,
-                         gboolean         visible)
-{
-    gtk_widget_set_visible (GTK_WIDGET (self->error_label), visible);
-    gtk_widget_set_visible (GTK_WIDGET (self->error_label_tag), visible);
-}
-
 static gboolean
 transform_to_state (GBinding     *binding G_GNUC_UNUSED,
                     const GValue *from_value,
@@ -206,18 +196,18 @@ bind_extension (ExmExtensionRow *self,
     g_object_set (self->prefs_btn, "visible", has_prefs, NULL);
     g_object_set (self->remove_btn, "visible", is_user, NULL);
     g_object_set (self->update_icon, "visible", has_update, NULL);
-    g_object_set (self->version_label, "label", version_name ? g_strdup_printf ("%s (%s)", version_name, version)
-                                                             : version, NULL);
+    g_object_set (self->version_row, "subtitle", version_name ? g_strdup_printf ("%s (%s)", version_name, version)
+                                                              : version, NULL);
 
     // Trim description label's leading and trailing whitespace
     char *description_trimmed = g_strchomp (g_strstrip (description));
-    g_object_set (self->description_label, "label", description_trimmed, NULL);
+    g_object_set (self->description_row, "subtitle", description_trimmed, NULL);
     g_free (description_trimmed);
 
     // Only show if error_msg exists and is not empty
-    g_object_set (self->error_label, "label", error_msg, NULL);
+    g_object_set (self->error_row, "subtitle", error_msg, NULL);
     gboolean has_error = (error_msg != NULL) && (strlen(error_msg) != 0);
-    set_error_label_visible (self, has_error);
+    gtk_widget_set_visible (GTK_WIDGET (self->error_row), has_error);
 
     gtk_widget_set_visible (GTK_WIDGET (self->error_icon), state == EXM_EXTENSION_STATE_ERROR);
     gtk_widget_set_visible (GTK_WIDGET (self->out_of_date_icon), state == EXM_EXTENSION_STATE_OUT_OF_DATE);
@@ -227,8 +217,7 @@ bind_extension (ExmExtensionRow *self,
                              || state == EXM_EXTENSION_STATE_INACTIVE)
                              && enabled);
 
-    gtk_widget_set_visible (GTK_WIDGET (self->version_title), version != NULL);
-    gtk_widget_set_visible (GTK_WIDGET (self->version_label), version != NULL);
+    gtk_widget_set_visible (GTK_WIDGET (self->version_row), version != NULL);
 
     gtk_actionable_set_action_target (GTK_ACTIONABLE (self->details_btn), "s", uuid);
 
@@ -314,11 +303,9 @@ exm_extension_row_class_init (ExmExtensionRowClass *klass)
 
     gtk_widget_class_set_template_from_resource (widget_class, g_strdup_printf ("%s/exm-extension-row.ui", RESOURCE_PATH));
 
-    gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, description_label);
-    gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, version_title);
-    gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, version_label);
-    gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, error_label);
-    gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, error_label_tag);
+    gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, description_row);
+    gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, version_row);
+    gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, error_row);
 
     gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, prefs_btn);
     gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, remove_btn);

--- a/src/style.css
+++ b/src/style.css
@@ -1,7 +1,3 @@
-.row-content {
-  padding: 10px;
-}
-
 .content {
   margin: 24px 12px;
 }


### PR DESCRIPTION
This replaces the GtkGrid with a series of AdwActionRow for the extension description, version, and error message. This makes the design more modern and in line with the rest of the app and other GNOME apps, and makes the app fit on smartphones.

Fixes https://github.com/mjakeman/extension-manager/issues/767

⚠️ I'm not sure if the `multiline` style class should change the whole row (hence the title and the description) or the description only. It's trivial to fix, just replace `.multiline {` by `.multiline .subtitle {` in the CSS file. Right now it affects both, which IMO looks a biut better, but I don't have a strong opinion. What do you think?

Are are screenshots of before and after this MR.

![Capture d’écran du 2025-01-20 10-46-19](https://github.com/user-attachments/assets/1ce7121b-37b2-4694-b77d-388080f8277e)

![Capture d’écran du 2025-01-20 10-46-03](https://github.com/user-attachments/assets/bad43b8e-deff-466c-9f01-a91e5e0ca3b0)
