### PR TITLE
Disable install button during installation

### DIFF
--- a/src/exm-browse-page.c
+++ b/src/exm-browse-page.c
@@ -41,7 +41,6 @@ struct _ExmBrowsePage
 
     GtkStringList *suggestions;
     GListModel *search_results_model;
-    gchar *shell_version;
 
     int current_page;
     int max_pages;
@@ -135,17 +134,9 @@ search_widget_factory (ExmSearchResult *result,
                        ExmBrowsePage   *self)
 {
     ExmSearchRow *row;
-    gchar *uuid;
-    gboolean is_installed;
-    gboolean is_supported;
     GValue value = G_VALUE_INIT;
 
-    g_object_get (result, "uuid", &uuid, NULL);
-
-    is_installed = exm_manager_is_installed_uuid (self->manager, uuid);
-    is_supported = exm_search_result_supports_shell_version (result, self->shell_version);
-
-    row = exm_search_row_new (result, is_installed, is_supported);
+    row = exm_search_row_new (self->manager, result);
 
     g_value_init (&value, G_TYPE_BOOLEAN);
     g_value_set_boolean (&value, TRUE);
@@ -355,7 +346,6 @@ on_bind_manager (ExmBrowsePage *self)
                   &shell_version,
                   NULL);
 
-    self->shell_version = shell_version;
     g_object_set (self->search, "shell-version", shell_version, NULL);
 
     refresh_search (self);

--- a/src/exm-install-button.c
+++ b/src/exm-install-button.c
@@ -128,6 +128,10 @@ update_state (ExmInstallButton *button)
         gtk_widget_set_sensitive (GTK_WIDGET (button), TRUE);
         gtk_widget_add_css_class (GTK_WIDGET (button), "suggested-action");
         break;
+    case EXM_INSTALL_BUTTON_STATE_INSTALLING:
+        gtk_label_set_label (button->label, _("Installing"));
+        gtk_widget_set_sensitive (GTK_WIDGET (button), FALSE);
+        break;
     case EXM_INSTALL_BUTTON_STATE_INSTALLED:
         gtk_label_set_label (button->label, C_("State", "Installed"));
         gtk_widget_set_sensitive (GTK_WIDGET (button), FALSE);

--- a/src/exm-search-row.c
+++ b/src/exm-search-row.c
@@ -31,23 +31,22 @@ struct _ExmSearchRow
 {
     GtkListBoxRow parent_instance;
 
+    ExmManager *manager;
     ExmSearchResult *search_result;
-    gboolean is_installed;
-    gboolean is_supported;
     gboolean compact;
     gchar *uuid;
 
     GtkLabel *description_label;
     ExmInstallButton *install_btn;
+    guint signal_id;
 };
 
 G_DEFINE_FINAL_TYPE (ExmSearchRow, exm_search_row, GTK_TYPE_LIST_BOX_ROW)
 
 enum {
     PROP_0,
+    PROP_MANAGER,
     PROP_SEARCH_RESULT,
-    PROP_IS_INSTALLED,
-    PROP_IS_SUPPORTED,
     PROP_COMPACT,
     N_PROPS
 };
@@ -55,14 +54,12 @@ enum {
 static GParamSpec *properties [N_PROPS];
 
 ExmSearchRow *
-exm_search_row_new (ExmSearchResult *search_result,
-                    gboolean         is_installed,
-                    gboolean         is_supported)
+exm_search_row_new (ExmManager      *manager,
+                    ExmSearchResult *search_result)
 {
     return g_object_new (EXM_TYPE_SEARCH_ROW,
+                         "manager", manager,
                          "search-result", search_result,
-                         "is-installed", is_installed,
-                         "is-supported", is_supported,
                          NULL);
 }
 
@@ -76,14 +73,11 @@ exm_search_row_get_property (GObject    *object,
 
     switch (prop_id)
     {
+    case PROP_MANAGER:
+        g_value_set_object (value, self->manager);
+        break;
     case PROP_SEARCH_RESULT:
         g_value_set_object (value, self->search_result);
-        break;
-    case PROP_IS_INSTALLED:
-        g_value_set_boolean (value, self->is_installed);
-        break;
-    case PROP_IS_SUPPORTED:
-        g_value_set_boolean (value, self->is_supported);
         break;
     case PROP_COMPACT:
         g_value_set_boolean (value, self->compact);
@@ -103,6 +97,9 @@ exm_search_row_set_property (GObject      *object,
 
     switch (prop_id)
     {
+    case PROP_MANAGER:
+        self->manager = g_value_get_object (value);
+        break;
     case PROP_SEARCH_RESULT:
         self->search_result = g_value_get_object (value);
         if (self->search_result)
@@ -113,18 +110,23 @@ exm_search_row_set_property (GObject      *object,
                           NULL);
         }
         break;
-    case PROP_IS_INSTALLED:
-        self->is_installed = g_value_get_boolean (value);
-        break;
-    case PROP_IS_SUPPORTED:
-        self->is_supported = g_value_get_boolean (value);
-        break;
     case PROP_COMPACT:
         self->compact = g_value_get_boolean (value);
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
+}
+
+static void
+on_install_status (ExmManager            *manager G_GNUC_UNUSED,
+                   ExmInstallButtonState  state,
+                   ExmSearchRow          *self)
+{
+    g_object_set (self->install_btn, "state", state, NULL);
+
+    if (self->signal_id > 0)
+        g_signal_handler_disconnect (self->manager, self->signal_id);
 }
 
 static void
@@ -136,7 +138,18 @@ install_remote (GtkButton    *button,
 
     g_object_get (self->install_btn, "state", &state, NULL);
 
+    self->signal_id = g_signal_connect_object (self->manager,
+                                               "install-status",
+                                               G_CALLBACK (on_install_status),
+                                               self,
+                                               G_CONNECT_DEFAULT);
+
     warn = (state == EXM_INSTALL_BUTTON_STATE_UNSUPPORTED);
+
+    g_object_set (self->install_btn, "state", EXM_INSTALL_BUTTON_STATE_INSTALLING, NULL);
+
+    gtk_widget_grab_focus (GTK_WIDGET (self));
+
     gtk_widget_activate_action (GTK_WIDGET (button),
                                 "ext.install",
                                 "(sb)", self->uuid, warn);
@@ -148,6 +161,8 @@ exm_search_row_constructed (GObject *object)
     ExmSearchRow *self = EXM_SEARCH_ROW (object);
 
     ExmInstallButtonState install_state;
+    gboolean is_installed;
+    gboolean is_supported;
 
     gchar *uuid, *description;
     g_object_get (self->search_result,
@@ -155,11 +170,19 @@ exm_search_row_constructed (GObject *object)
                   "description", &description,
                   NULL);
 
-    gtk_actionable_set_action_target (GTK_ACTIONABLE (self), "s", uuid);
+    gchar *shell_version;
+    g_object_get (self->manager,
+                  "shell-version",
+                  &shell_version,
+                  NULL);
 
-    install_state = self->is_installed
+    gtk_actionable_set_action_target (GTK_ACTIONABLE (self), "s", uuid);
+    is_installed = exm_manager_is_installed_uuid (self->manager, uuid);
+    is_supported = exm_search_result_supports_shell_version (self->search_result, shell_version);
+
+    install_state = is_installed
         ? EXM_INSTALL_BUTTON_STATE_INSTALLED
-        : (self->is_supported
+        : (is_supported
            ? EXM_INSTALL_BUTTON_STATE_DEFAULT
            : EXM_INSTALL_BUTTON_STATE_UNSUPPORTED);
 
@@ -190,26 +213,19 @@ exm_search_row_class_init (ExmSearchRowClass *klass)
     object_class->set_property = exm_search_row_set_property;
     object_class->constructed = exm_search_row_constructed;
 
+    properties [PROP_MANAGER]
+        = g_param_spec_object ("manager",
+                               "Manager",
+                               "Manager",
+                               EXM_TYPE_MANAGER,
+                               G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY);
+
     properties [PROP_SEARCH_RESULT] =
         g_param_spec_object ("search-result",
                              "Search Result",
                              "Search Result",
                              EXM_TYPE_SEARCH_RESULT,
                              G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY);
-
-    properties [PROP_IS_INSTALLED] =
-        g_param_spec_boolean ("is-installed",
-                              "Is Installed",
-                              "Is Installed",
-                              FALSE,
-                              G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY);
-
-    properties [PROP_IS_SUPPORTED] =
-        g_param_spec_boolean ("is-supported",
-                              "Is Supported",
-                              "Is Supported",
-                              FALSE,
-                              G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY);
 
     properties [PROP_COMPACT] =
         g_param_spec_boolean ("compact",

--- a/src/exm-search-row.h
+++ b/src/exm-search-row.h
@@ -1,7 +1,29 @@
+/*
+ * exm-search-row.h
+ *
+ * Copyright 2022-2025 Matthew Jakeman <mjakeman26@outlook.co.nz>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #pragma once
 
-#include <adwaita.h>
+#include <gtk/gtk.h>
 
+#include "local/exm-manager.h"
 #include "web/model/exm-search-result.h"
 
 G_BEGIN_DECLS
@@ -10,8 +32,7 @@ G_BEGIN_DECLS
 
 G_DECLARE_FINAL_TYPE (ExmSearchRow, exm_search_row, EXM, SEARCH_ROW, GtkListBoxRow)
 
-ExmSearchRow *exm_search_row_new (ExmSearchResult *search_result,
-                                  gboolean         is_installed,
-                                  gboolean         is_supported);
+ExmSearchRow *exm_search_row_new (ExmManager      *manager,
+                                  ExmSearchResult *search_result);
 
 G_END_DECLS

--- a/src/exm-types.h
+++ b/src/exm-types.h
@@ -1,3 +1,24 @@
+/*
+ * exm-types.h
+ *
+ * Copyright 2022-2025 Matthew Jakeman <mjakeman26@outlook.co.nz>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #pragma once
 
 // Should really be in the `local/` subdirectory but meson's mkenums
@@ -25,6 +46,7 @@ typedef enum
 typedef enum
 {
     EXM_INSTALL_BUTTON_STATE_DEFAULT,
+    EXM_INSTALL_BUTTON_STATE_INSTALLING,
     EXM_INSTALL_BUTTON_STATE_INSTALLED,
     EXM_INSTALL_BUTTON_STATE_UNSUPPORTED
 } ExmInstallButtonState;

--- a/src/exm-window.c
+++ b/src/exm-window.c
@@ -159,10 +159,12 @@ on_install_done (GObject       *source,
                  gpointer       user_data G_GNUC_UNUSED)
 {
     GError *error = NULL;
-    if (!exm_manager_install_finish (EXM_MANAGER (source), res, &error) && error)
+
+    if (!exm_manager_install_finish (source, res, &error) && error)
     {
         // TODO: Properly log this
         g_critical ("%s\n", error->message);
+        g_clear_error (&error);
     }
 }
 

--- a/src/exm-window.c
+++ b/src/exm-window.c
@@ -27,6 +27,7 @@
 #include "exm-error-dialog.h"
 #include "exm-installed-page.h"
 #include "exm-screenshot-view.h"
+#include "exm-types.h"
 #include "exm-upgrade-assistant.h"
 #include "local/exm-extension.h"
 #include "local/exm-manager.h"
@@ -121,10 +122,8 @@ extension_remove_dialog_response (AdwAlertDialog   *dialog,
 {
     const char *response = adw_alert_dialog_choose_finish (dialog, result);
 
-    if (strcmp(response, "yes") == 0)
-    {
+    if (g_str_equal (response, "yes"))
         exm_manager_remove_extension (data->manager, data->extension);
-    }
 
     g_clear_pointer (&data->manager, g_object_unref);
     g_clear_pointer (&data->extension, g_object_unref);
@@ -153,26 +152,59 @@ extension_remove (GtkWidget  *widget,
                              (GAsyncReadyCallback) extension_remove_dialog_response, data);
 }
 
-static void
-on_install_done (GObject       *source,
-                 GAsyncResult  *res,
-                 gpointer       user_data G_GNUC_UNUSED)
-{
-    GError *error = NULL;
-
-    if (!exm_manager_install_finish (source, res, &error) && error)
-    {
-        // TODO: Properly log this
-        g_critical ("%s\n", error->message);
-        g_clear_error (&error);
-    }
-}
-
 typedef struct
 {
     ExmManager *manager;
     gchar *uuid;
 } UnsupportedDialogData;
+
+static void
+on_install_done (GObject      *source,
+                 GAsyncResult *res,
+                 gpointer      user_data)
+{
+    ExmWindow *self = NULL;
+    UnsupportedDialogData *data = NULL;
+    ExmManager *manager = NULL;
+    ExmInstallButtonState state;
+    GError *error = NULL;
+
+    if (G_IS_OBJECT (user_data))
+    {
+        self = (ExmWindow *)user_data;
+        manager = self->manager;
+        state = EXM_INSTALL_BUTTON_STATE_DEFAULT;
+    }
+    else
+    {
+        data = (UnsupportedDialogData *)user_data;
+        manager = data->manager;
+        state = EXM_INSTALL_BUTTON_STATE_UNSUPPORTED;
+    }
+
+    if (!exm_manager_install_finish (source, res, &error))
+    {
+        // TODO: Properly log this
+        if (error)
+        {
+            g_critical ("%s\n", error->message);
+            g_clear_error (&error);
+        }
+
+        g_signal_emit_by_name (manager, "install-status", state);
+    }
+    else
+    {
+        g_signal_emit_by_name (manager, "install-status", EXM_INSTALL_BUTTON_STATE_INSTALLED);
+    }
+
+    if (data)
+    {
+        g_clear_pointer (&data->manager, g_object_unref);
+        g_clear_pointer (&data->uuid, g_free);
+        g_free (data);
+    }
+}
 
 static void
 extension_unsupported_dialog_response (AdwAlertDialog        *dialog,
@@ -181,16 +213,20 @@ extension_unsupported_dialog_response (AdwAlertDialog        *dialog,
 {
     const char *response = adw_alert_dialog_choose_finish (dialog, result);
 
-    if (strcmp(response, "install") == 0)
+    if (g_str_equal (response, "install"))
     {
         exm_manager_install_async (data->manager, data->uuid, NULL,
                                    (GAsyncReadyCallback) on_install_done,
-                                   NULL);
+                                   data);
     }
+    else
+    {
+        g_signal_emit_by_name (data->manager, "install-status", EXM_INSTALL_BUTTON_STATE_UNSUPPORTED);
 
-    g_clear_pointer (&data->manager, g_object_unref);
-    g_clear_pointer (&data->uuid, g_free);
-    g_free (data);
+        g_clear_pointer (&data->manager, g_object_unref);
+        g_clear_pointer (&data->uuid, g_free);
+        g_free (data);
+    }
 }
 
 static void
@@ -210,6 +246,7 @@ extension_install (GtkWidget  *widget,
         UnsupportedDialogData *data = g_new0 (UnsupportedDialogData, 1);
         data->manager = g_object_ref (self->manager);
         data->uuid = g_strdup (uuid);
+        g_free (uuid);
 
         adw_alert_dialog_choose (self->unsupported_dialog, widget, NULL,
                                  (GAsyncReadyCallback) extension_unsupported_dialog_response, data);
@@ -328,7 +365,7 @@ search_online (GtkWidget  *widget,
     search_entry = exm_browse_page_get_search_entry (self->browse_page);
     search_text = gtk_editable_get_text (GTK_EDITABLE (gtk_search_bar_get_child (self->search_bar)));
     adw_view_stack_set_visible_child_name (self->view_stack, "browse");
-    gtk_editable_set_text (GTK_EDITABLE (search_entry) , search_text);
+    gtk_editable_set_text (GTK_EDITABLE (search_entry), search_text);
     gtk_toggle_button_set_active (self->search_button, FALSE);
 }
 

--- a/src/local/exm-manager.c
+++ b/src/local/exm-manager.c
@@ -21,7 +21,6 @@
 
 #include "exm-manager.h"
 
-#include "exm-extension.h"
 #include "shell-dbus-interface.h"
 
 #include "../exm-types.h"
@@ -353,29 +352,6 @@ exm_manager_is_installed_uuid (ExmManager  *self,
     return FALSE;
 }
 
-static void
-do_install_thread (GTask        *task,
-                   ExmManager   *self,
-                   const char   *uuid,
-                   GCancellable *cancellable)
-{
-    GError *error = NULL;
-
-    g_dbus_proxy_call_sync (G_DBUS_PROXY (self->proxy),
-                            "InstallRemoteExtension",
-                            g_variant_new ("(s)", uuid, NULL),
-                            G_DBUS_CALL_FLAGS_NONE,
-                            -1, cancellable, &error);
-
-    if (error != NULL)
-    {
-        g_task_return_error (task, error);
-        return;
-    }
-
-    g_task_return_boolean (task, TRUE);
-}
-
 void
 exm_manager_install_async (ExmManager          *self,
                            const gchar         *uuid,
@@ -383,22 +359,24 @@ exm_manager_install_async (ExmManager          *self,
                            GAsyncReadyCallback  callback,
                            gpointer             user_data)
 {
-    GTask *task;
-
-    task = g_task_new (self, cancellable, callback, user_data);
-    g_task_set_task_data (task, g_strdup (uuid), (GDestroyNotify) g_free);
-    g_task_run_in_thread (task, (GTaskThreadFunc)do_install_thread);
-    g_object_unref (task);
+    shell_extensions_call_install_remote_extension (self->proxy,
+                                                    uuid,
+                                                    cancellable,
+                                                    callback,
+                                                    user_data);
 }
 
 gboolean
-exm_manager_install_finish (ExmManager    *self,
+exm_manager_install_finish (GObject       *self,
                             GAsyncResult  *result,
                             GError       **error)
 {
-    g_return_val_if_fail (g_task_is_valid (result, self), FALSE);
+    g_return_val_if_fail (SHELL_IS_EXTENSIONS (self), FALSE);
 
-    return g_task_propagate_boolean (G_TASK (result), error);
+    return shell_extensions_call_install_remote_extension_finish (SHELL_EXTENSIONS (self),
+                                                                  NULL,
+                                                                  result,
+                                                                  error);
 }
 
 static int

--- a/src/local/exm-manager.h
+++ b/src/local/exm-manager.h
@@ -1,3 +1,24 @@
+/*
+ * exm-manager.h
+ *
+ * Copyright 2022-2025 Matthew Jakeman <mjakeman26@outlook.co.nz>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #pragma once
 
 #include <glib-object.h>
@@ -11,23 +32,27 @@ G_BEGIN_DECLS
 
 G_DECLARE_FINAL_TYPE (ExmManager, exm_manager, EXM, MANAGER, GObject)
 
-ExmManager *exm_manager_new (void);
-void exm_manager_enable_extension (ExmManager *manager, ExmExtension *extension);
-void exm_manager_disable_extension (ExmManager *manager, ExmExtension *extension);
-void exm_manager_remove_extension (ExmManager *self, ExmExtension *extension);
-void exm_manager_open_prefs (ExmManager *self, ExmExtension *extension);
-void exm_manager_check_for_updates (ExmManager *self);
-gboolean exm_manager_is_installed_uuid (ExmManager *self, const gchar *uuid);
-ExmExtension *exm_manager_get_by_uuid (ExmManager  *self, const gchar *uuid);
-
-void exm_manager_install_async (ExmManager          *self,
-                                const gchar         *uuid,
-                                GCancellable        *cancellable,
-                                GAsyncReadyCallback  callback,
-                                gpointer             user_data);
-
-gboolean exm_manager_install_finish (ExmManager    *self,
-                                     GAsyncResult  *result,
-                                     GError       **error);
+ExmManager   *exm_manager_new (void);
+void          exm_manager_enable_extension  (ExmManager           *manager,
+                                             ExmExtension         *extension);
+void          exm_manager_disable_extension (ExmManager           *manager,
+                                             ExmExtension         *extension);
+void          exm_manager_remove_extension  (ExmManager           *self,
+                                             ExmExtension         *extension);
+void          exm_manager_open_prefs        (ExmManager           *self,
+                                             ExmExtension         *extension);
+void          exm_manager_check_for_updates (ExmManager           *self);
+gboolean      exm_manager_is_installed_uuid (ExmManager           *self,
+                                             const gchar          *uuid);
+ExmExtension *exm_manager_get_by_uuid       (ExmManager           *self,
+                                             const gchar          *uuid);
+void          exm_manager_install_async     (ExmManager           *self,
+                                             const gchar          *uuid,
+                                             GCancellable         *cancellable,
+                                             GAsyncReadyCallback   callback,
+                                             gpointer              user_data);
+gboolean      exm_manager_install_finish    (GObject              *self,
+                                             GAsyncResult         *result,
+                                             GError              **error);
 
 G_END_DECLS


### PR DESCRIPTION
From the main commit:

```
Introduces a new installing state that is set before activating
`ext.install` action. To deal with cancellations, a new `install-status`
signal is added to ExmManager which is emitted whenever it happens and
reverts the button state to the last one it had, either default or
unsupported.

ExmSearchRow drops `is-installed` and `is-supported` properties in favor
of a new `manager` property to connect to ExmManager's `install-status`
signal.
```

Fix #673