### PR TITLE
installed-page: Save extension's toggle focus on state changes

### DIFF
--- a/src/exm-extension-row.c
+++ b/src/exm-extension-row.c
@@ -323,6 +323,12 @@ on_state_changed (GtkSwitch        *toggle,
     return TRUE;
 }
 
+void
+exm_search_row_focus_toggle (ExmExtensionRow *self)
+{
+    gtk_widget_grab_focus (GTK_WIDGET (self->ext_toggle));
+}
+
 static void
 exm_extension_row_class_init (ExmExtensionRowClass *klass)
 {

--- a/src/exm-extension-row.h
+++ b/src/exm-extension-row.h
@@ -11,8 +11,9 @@ G_BEGIN_DECLS
 
 G_DECLARE_FINAL_TYPE (ExmExtensionRow, exm_extension_row, EXM, EXTENSION_ROW, AdwExpanderRow)
 
-ExmExtensionRow *
-exm_extension_row_new (ExmExtension *extension,
-                       ExmManager   *manager);
+ExmExtensionRow *exm_extension_row_new       (ExmExtension *extension,
+                                              ExmManager   *manager);
+
+void             exm_search_row_focus_toggle (ExmExtensionRow *self);
 
 G_END_DECLS

--- a/src/exm-installed-page.blp
+++ b/src/exm-installed-page.blp
@@ -38,7 +38,7 @@ template $ExmInstalledPage: Gtk.Widget {
             Gtk.ListBox user_list_box {
               styles [
                 "boxed-list",
-                "boxed-list-placeholder"
+                "boxed-list-placeholder",
               ]
 
               selection-mode: none;
@@ -73,7 +73,7 @@ template $ExmInstalledPage: Gtk.Widget {
             Gtk.ListBox system_list_box {
               styles [
                 "boxed-list",
-                "boxed-list-placeholder"
+                "boxed-list-placeholder",
               ]
 
               selection-mode: none;
@@ -104,7 +104,7 @@ template $ExmInstalledPage: Gtk.Widget {
         Adw.PreferencesGroup {
           Gtk.ListBox search_list_box {
             styles [
-              "boxed-list"
+              "boxed-list",
             ]
 
             selection-mode: none;
@@ -128,7 +128,7 @@ template $ExmInstalledPage: Gtk.Widget {
 
         child: Gtk.Button {
           styles [
-            "pill"
+            "pill",
           ]
 
           label: _("_Search Online");

--- a/src/local/exm-extension.c
+++ b/src/local/exm-extension.c
@@ -199,6 +199,25 @@ exm_extension_set_property (GObject      *object,
     }
 }
 
+gint
+compare_extension (ExmExtension *a,
+                   ExmExtension *b,
+                   gpointer      user_data G_GNUC_UNUSED)
+{
+    const gchar *uuid_a, *uuid_b;
+    g_object_get (a, "uuid", &uuid_a, NULL);
+    g_object_get (b, "uuid", &uuid_b, NULL);
+
+    return g_strcmp0 (uuid_a, uuid_b);
+}
+
+gboolean
+is_extension_equal (ExmExtension *a,
+                    ExmExtension *b)
+{
+    return compare_extension (a, b, NULL) == 0;
+}
+
 static void
 exm_extension_class_init (ExmExtensionClass *klass)
 {

--- a/src/local/exm-extension.h
+++ b/src/local/exm-extension.h
@@ -8,6 +8,13 @@ G_BEGIN_DECLS
 
 G_DECLARE_FINAL_TYPE (ExmExtension, exm_extension, EXM, EXTENSION, GObject)
 
-ExmExtension *exm_extension_new (const gchar *uuid);
+ExmExtension *exm_extension_new  (const gchar *uuid);
+
+gint          compare_extension  (ExmExtension *a,
+                                  ExmExtension *b,
+                                  gpointer      user_data);
+
+gboolean      is_extension_equal (ExmExtension *a,
+                                  ExmExtension *b);
 
 G_END_DECLS


### PR DESCRIPTION
The items-changed signal is now emitted without adding or removing items to the model from ExmManager and is connected after binding the manager in ExmInstalledPage from where the callback saves, emits items-changed adding and removing as done before in ExmManager, and restores focus.

This approach allows us to keep binding GtkListBox to the extensions model and not having to manage the changes manually.

Fix https://github.com/mjakeman/extension-manager/issues/220