### PR TITLE
extension-row: Add Session Modes row

### DIFF
--- a/src/exm-extension-row.blp
+++ b/src/exm-extension-row.blp
@@ -80,23 +80,6 @@ template $ExmExtensionRow: Adw.ExpanderRow {
     tooltip-text: _("A newer version of this extension is available");
   }
 
-  [suffix]
-  Gtk.Image info_icon {
-    styles [
-      "warning",
-    ]
-
-    icon-name: "dialog-information-symbolic";
-    valign: center;
-    halign: center;
-    focusable: true;
-    margin-start: 9;
-    margin-end: 9;
-    visible: false;
-    // Translators: Icon's tooltip when an extension works in login and/or lock screen session modes
-    tooltip-text: _("This extension could be activated in session modes such as the login screen or the lock screen");
-  }
-
   Adw.ActionRow description_row {
     styles [
       "multiline",
@@ -114,6 +97,21 @@ template $ExmExtensionRow: Adw.ExpanderRow {
 
     title: _("Version");
     subtitle: bind template.extension as <$ExmExtension>.version;
+  }
+
+  Adw.ActionRow session_modes_row {
+    styles [
+      "property",
+    ]
+
+    title: _("Session Modes");
+    visible: false;
+
+    [suffix]
+    Gtk.Image info_icon {
+      focusable: true;
+      icon-name: "dialog-information-symbolic";
+    }
   }
 
   Adw.ActionRow error_row {

--- a/src/exm-extension-row.blp
+++ b/src/exm-extension-row.blp
@@ -17,7 +17,7 @@ template $ExmExtensionRow: Adw.ExpanderRow {
   [suffix]
   Gtk.Button prefs_btn {
     styles [
-      "flat"
+      "flat",
     ]
 
     icon-name: "settings-symbolic";
@@ -32,7 +32,7 @@ template $ExmExtensionRow: Adw.ExpanderRow {
   [suffix]
   Gtk.Image error_icon {
     styles [
-      "error"
+      "error",
     ]
 
     icon-name: "dialog-error-symbolic";
@@ -49,7 +49,7 @@ template $ExmExtensionRow: Adw.ExpanderRow {
   [suffix]
   Gtk.Image out_of_date_icon {
     styles [
-      "error"
+      "error",
     ]
 
     icon-name: "clock-alt-symbolic";
@@ -66,7 +66,7 @@ template $ExmExtensionRow: Adw.ExpanderRow {
   [suffix]
   Gtk.Image update_icon {
     styles [
-      "update"
+      "update",
     ]
 
     icon-name: "software-update-available-symbolic";
@@ -83,7 +83,7 @@ template $ExmExtensionRow: Adw.ExpanderRow {
   [suffix]
   Gtk.Image info_icon {
     styles [
-      "warning"
+      "warning",
     ]
 
     icon-name: "dialog-information-symbolic";
@@ -100,7 +100,7 @@ template $ExmExtensionRow: Adw.ExpanderRow {
   Adw.ActionRow description_row {
     styles [
       "multiline",
-      "property"
+      "property",
     ]
 
     title: _("Description");
@@ -109,21 +109,22 @@ template $ExmExtensionRow: Adw.ExpanderRow {
 
   Adw.ActionRow version_row {
     styles [
-      "property"
+      "property",
     ]
 
     title: _("Version");
+    subtitle: bind template.extension as <$ExmExtension>.version;
   }
 
   Adw.ActionRow error_row {
     styles [
       "monospace",
       "multiline",
-      "property"
+      "property",
     ]
 
     title: _("Error");
-    subtitle: bind template.extension as <$ExmExtension>.error_msg;
+    subtitle: bind template.extension as <$ExmExtension>.error;
     subtitle-selectable: true;
   }
 
@@ -140,7 +141,7 @@ template $ExmExtensionRow: Adw.ExpanderRow {
 
       Gtk.Button details_btn {
         styles [
-          "flat"
+          "flat",
         ]
 
         label: _("See Details");
@@ -151,7 +152,7 @@ template $ExmExtensionRow: Adw.ExpanderRow {
 
       Gtk.Button remove_btn {
         styles [
-          "destructive-action"
+          "destructive-action",
         ]
 
         label: _("Remove…");

--- a/src/exm-extension-row.c
+++ b/src/exm-extension-row.c
@@ -21,10 +21,11 @@
 
 #include "exm-extension-row.h"
 
+#include "exm-config.h"
 #include "exm-enums.h"
 #include "exm-types.h"
 
-#include "exm-config.h"
+#include <glib/gi18n.h>
 
 struct _ExmExtensionRow
 {
@@ -44,12 +45,13 @@ struct _ExmExtensionRow
 
     AdwActionRow *description_row;
     AdwActionRow *version_row;
+    AdwActionRow *session_modes_row;
+    GtkImage *info_icon;
     AdwActionRow *error_row;
 
     GtkImage *update_icon;
     GtkImage *error_icon;
     GtkImage *out_of_date_icon;
-    GtkImage *info_icon;
 };
 
 G_DEFINE_FINAL_TYPE (ExmExtensionRow, exm_extension_row, ADW_TYPE_EXPANDER_ROW)
@@ -154,6 +156,62 @@ unbind_extension (ExmExtensionRow *self)
 }
 
 static void
+add_session_modes (GPtrArray       *session_modes,
+                   ExmExtensionRow *self)
+{
+    if (!session_modes || session_modes->len == 0)
+        return;
+
+    GPtrArray *subtitles = g_ptr_array_new_with_free_func (g_free);
+    gboolean has_unlock_dialog = FALSE;
+    gboolean has_gdm = FALSE;
+
+    for (guint i = 0; i < session_modes->len; i++)
+    {
+        gchar *mode = g_ptr_array_index (session_modes, i);
+
+        if (g_strcmp0 (mode, "unlock-dialog") == 0)
+        {
+            g_ptr_array_add (subtitles, g_strdup (_("Unlock Dialog")));
+            has_unlock_dialog = TRUE;
+        }
+        else if (g_strcmp0 (mode, "gdm") == 0)
+        {
+            // Translators: GNOME Display Manager
+            g_ptr_array_add (subtitles, g_strdup (_("GDM")));
+            has_gdm = TRUE;
+        }
+    }
+
+    if (has_unlock_dialog && has_gdm)
+    {
+        // Translators: Icon's tooltip when an extension runs on both, login and lock screens
+        gtk_widget_set_tooltip_text (GTK_WIDGET (self->info_icon), _("This extension will run while the screen is locked and no user is logged in"));
+    }
+    else if (has_unlock_dialog)
+    {
+        // Translators: Icon's tooltip when an extension runs on the lock screen
+        gtk_widget_set_tooltip_text (GTK_WIDGET (self->info_icon), _("This extension will run while the screen is locked"));
+    }
+    else if (has_gdm)
+    {
+        // Translators: Icon's tooltip when an extension runs on the login screen
+        gtk_widget_set_tooltip_text (GTK_WIDGET (self->info_icon), _("This extension will run while no user is logged in"));
+    }
+
+    if (subtitles->len > 0)
+    {
+        g_ptr_array_add (subtitles, NULL);
+        gchar *subtitle = g_strjoinv (" / ", (gchar **)subtitles->pdata);
+        adw_action_row_set_subtitle (self->session_modes_row, subtitle);
+        gtk_widget_set_visible (GTK_WIDGET (self->session_modes_row), TRUE);
+        g_free (subtitle);
+    }
+
+    g_ptr_array_free (subtitles, TRUE);
+}
+
+static void
 bind_extension (ExmExtensionRow *self,
                 ExmExtension    *extension)
 {
@@ -176,6 +234,7 @@ bind_extension (ExmExtensionRow *self,
     gchar *name, *uuid, *description, *version, *error;
     gboolean enabled, has_prefs, is_user;
     ExmExtensionState state;
+    GPtrArray *session_modes;
     g_object_get (self->extension,
                   "name", &name,
                   "uuid", &uuid,
@@ -186,6 +245,7 @@ bind_extension (ExmExtensionRow *self,
                   "error", &error,
                   "has-prefs", &has_prefs,
                   "is-user", &is_user,
+                  "session-modes", &session_modes,
                   NULL);
 
     self->uuid = g_strdup (uuid);
@@ -204,14 +264,11 @@ bind_extension (ExmExtensionRow *self,
     gtk_widget_set_visible (GTK_WIDGET (self->error_icon), state == EXM_EXTENSION_STATE_ERROR);
     gtk_widget_set_visible (GTK_WIDGET (self->out_of_date_icon), state == EXM_EXTENSION_STATE_OUT_OF_DATE);
 
-    gtk_widget_set_visible (GTK_WIDGET (self->info_icon),
-                            (state == EXM_EXTENSION_STATE_INITIALIZED
-                             || state == EXM_EXTENSION_STATE_INACTIVE)
-                             && enabled);
-
     gtk_widget_set_visible (GTK_WIDGET (self->version_row), version != NULL);
 
     gtk_actionable_set_action_target (GTK_ACTIONABLE (self->details_btn), "s", uuid);
+
+    add_session_modes (session_modes, self);
 
     GAction *action;
 
@@ -297,6 +354,8 @@ exm_extension_row_class_init (ExmExtensionRowClass *klass)
 
     gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, description_row);
     gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, version_row);
+    gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, session_modes_row);
+    gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, info_icon);
     gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, error_row);
 
     gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, prefs_btn);
@@ -306,7 +365,6 @@ exm_extension_row_class_init (ExmExtensionRowClass *klass)
     gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, update_icon);
     gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, error_icon);
     gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, out_of_date_icon);
-    gtk_widget_class_bind_template_child (widget_class, ExmExtensionRow, info_icon);
 
     gtk_widget_class_bind_template_callback (widget_class, on_state_changed);
 }

--- a/src/exm-extension-row.c
+++ b/src/exm-extension-row.c
@@ -173,35 +173,32 @@ bind_extension (ExmExtensionRow *self,
     if (self->extension == NULL)
         return;
 
-    gchar *name, *uuid, *description, *version, *version_name, *error_msg;
+    gchar *name, *uuid, *description, *version, *error;
     gboolean enabled, has_prefs, is_user;
     ExmExtensionState state;
     g_object_get (self->extension,
-                  "display-name", &name,
+                  "name", &name,
                   "uuid", &uuid,
                   "description", &description,
                   "state", &state,
                   "enabled", &enabled,
+                  "version", &version,
+                  "error", &error,
                   "has-prefs", &has_prefs,
                   "is-user", &is_user,
-                  "version", &version,
-                  "version-name", &version_name,
-                  "error-msg", &error_msg,
                   NULL);
 
     self->uuid = g_strdup (uuid);
 
-    g_object_set (self, "title", g_markup_escape_text(name, -1), NULL);
-    adw_action_row_set_subtitle (self->version_row, version_name ? g_strdup_printf ("%s (%s)", version_name, version)
-                                                                 : version);
+    g_object_set (self, "title", g_markup_escape_text (name, -1), NULL);
 
     // Trim description label's leading and trailing whitespace
     char *description_trimmed = g_strchomp (g_strstrip (description));
     adw_action_row_set_subtitle (self->description_row, description_trimmed);
     g_free (description_trimmed);
 
-    // Only show if error_msg exists and is not empty
-    gboolean has_error = (error_msg != NULL) && (strlen(error_msg) != 0);
+    // Only show if error exists and is not empty
+    gboolean has_error = (error != NULL) && (strlen (error) != 0);
     gtk_widget_set_visible (GTK_WIDGET (self->error_row), has_error);
 
     gtk_widget_set_visible (GTK_WIDGET (self->error_icon), state == EXM_EXTENSION_STATE_ERROR);

--- a/src/exm-installed-page.c
+++ b/src/exm-installed-page.c
@@ -214,7 +214,7 @@ bind_list_box (GListModel       *model,
     g_return_if_fail (G_IS_LIST_MODEL (model));
 
     // Sort alphabetically
-    expression = gtk_property_expression_new (EXM_TYPE_EXTENSION, NULL, "display-name");
+    expression = gtk_property_expression_new (EXM_TYPE_EXTENSION, NULL, "name");
     alphabetical_sorter = gtk_string_sorter_new (expression);
 
     if (self->sort_enabled_first)

--- a/src/exm-upgrade-result.c
+++ b/src/exm-upgrade-result.c
@@ -116,7 +116,7 @@ exm_upgrade_result_get_name (ExmUpgradeResult *self)
 
     if (self->local_data)
     {
-        g_object_get (self->local_data, "display-name", &name, NULL);
+        g_object_get (self->local_data, "name", &name, NULL);
         return name;
     }
 


### PR DESCRIPTION
Shows the session modes in a new row. It should also help with https://github.com/mjakeman/extension-manager/pull/773 since this approach doesn't rely on extensions' state, which is giving some issues there.

It also adds url and donations properties for future use.

About how the switch status is shown, I have checked again and we don't differ on the behavior with Extensions, so #646 could have been closed a while ago I think. I'll still take the opportunity and close it with these changes.

![image](https://github.com/user-attachments/assets/8c6388c8-37e8-4f43-abb5-ea70cf949f32)

Close #646