### PR TITLE
detail-view: Hide "Show All Reviews" button when unneeded

### DIFF
--- a/src/exm-comment-dialog.blp
+++ b/src/exm-comment-dialog.blp
@@ -10,7 +10,7 @@ template $ExmCommentDialog: Adw.Dialog {
   content-height: 600;
   width-request: 360;
   height-request: 294;
-  title: _("Comments");
+  title: _("Reviews and Comments");
 
   child: Adw.ToolbarView {
     [top]
@@ -22,7 +22,7 @@ template $ExmCommentDialog: Adw.Dialog {
 
         child: Adw.StatusPage loading_status {
           paintable: spinner;
-          title: _("Loading Comments");
+          title: _("Loading");
         };
       }
 
@@ -42,7 +42,7 @@ template $ExmCommentDialog: Adw.Dialog {
           Adw.PreferencesGroup {
             Gtk.ListBox list_box {
               styles [
-                "boxed-list"
+                "boxed-list",
               ]
 
               selection-mode: none;

--- a/src/exm-detail-view.blp
+++ b/src/exm-detail-view.blp
@@ -72,7 +72,7 @@ template $ExmDetailView: Adw.NavigationPage {
 
               Gtk.Box {
                 styles [
-                  "detail"
+                  "detail",
                 ]
 
                 orientation: vertical;
@@ -100,7 +100,7 @@ template $ExmDetailView: Adw.NavigationPage {
 
                       Gtk.Label ext_title {
                         styles [
-                          "title-1"
+                          "title-1",
                         ]
 
                         ellipsize: end;
@@ -117,7 +117,7 @@ template $ExmDetailView: Adw.NavigationPage {
 
                       Gtk.Label ext_author {
                         styles [
-                          "dim-label"
+                          "dim-label",
                         ]
 
                         xalign: 0;
@@ -142,7 +142,7 @@ template $ExmDetailView: Adw.NavigationPage {
                   Gtk.Button ext_screenshot_popout_button {
                     styles [
                       "osd",
-                      "circular"
+                      "circular",
                     ]
 
                     icon-name: "pip-out-symbolic";
@@ -167,7 +167,7 @@ template $ExmDetailView: Adw.NavigationPage {
                   Gtk.Label description {
                     styles [
                       "title-4",
-                      "detail-heading"
+                      "detail-heading",
                     ]
 
                     label: _("Description");
@@ -176,7 +176,7 @@ template $ExmDetailView: Adw.NavigationPage {
 
                   Gtk.Label ext_description {
                     styles [
-                      "multiline"
+                      "multiline",
                     ]
 
                     xalign: 0;
@@ -243,10 +243,10 @@ template $ExmDetailView: Adw.NavigationPage {
                   Gtk.Label {
                     styles [
                       "title-4",
-                      "detail-heading"
+                      "detail-heading",
                     ]
 
-                    label: _("User Reviews");
+                    label: _("Reviews and Comments");
                     xalign: 0;
                     selectable: true;
                   }
@@ -269,10 +269,11 @@ template $ExmDetailView: Adw.NavigationPage {
                       name: "page_disabled";
 
                       child: Gtk.Label {
-                        label: _("Comments are disabled for this extension");
-                        valign: start;
-                        xalign: 0;
+                        label: _("Reviews and comments are disabled for this extension");
                         selectable: true;
+                        valign: start;
+                        wrap: true;
+                        xalign: 0;
                       };
                     }
 
@@ -285,7 +286,7 @@ template $ExmDetailView: Adw.NavigationPage {
 
                         Gtk.Label {
                           styles [
-                            "heading"
+                            "heading",
                           ]
 
                           label: _("Connection Error");
@@ -296,7 +297,7 @@ template $ExmDetailView: Adw.NavigationPage {
 
                         Gtk.Label error_label {
                           styles [
-                            "body"
+                            "body",
                           ]
 
                           selectable: true;
@@ -311,10 +312,11 @@ template $ExmDetailView: Adw.NavigationPage {
                       name: "page_empty";
 
                       child: Gtk.Label {
-                        label: _("No comments yet");
-                        valign: start;
-                        xalign: 0;
+                        label: _("There are no reviews or comments");
                         selectable: true;
+                        valign: start;
+                        wrap: true;
+                        xalign: 0;
                       };
                     }
 
@@ -335,9 +337,13 @@ template $ExmDetailView: Adw.NavigationPage {
                         }
 
                         Gtk.Button show_more_btn {
-                          label: _("_Show All Reviews");
+                          styles [
+                            "pill",
+                          ]
+
                           can-shrink: true;
                           halign: center;
+                          label: _("_Show All");
                           use-underline: true;
                         }
                       };

--- a/src/exm-detail-view.c
+++ b/src/exm-detail-view.c
@@ -248,10 +248,17 @@ on_get_comments (GObject       *source,
         return;
     }
 
-    if (g_list_model_get_n_items (model) == 0)
+    guint n_comments = g_list_model_get_n_items (model);
+
+    if (!n_comments)
+    {
         gtk_stack_set_visible_child_name (self->comment_stack, "page_empty");
+    }
     else
+    {
+        gtk_widget_set_visible (GTK_WIDGET (self->show_more_btn), n_comments >= 5);
         gtk_stack_set_visible_child_name (self->comment_stack, "page_comments");
+    }
 
     gtk_flow_box_bind_model (self->comment_box, model,
                              (GtkFlowBoxCreateWidgetFunc) comment_factory,


### PR DESCRIPTION
We retrieve reviews/comments in the details view and the comment dialog using different queries. Because we do not know the total count until querying all of them in the dialog, we have to display the button for extensions with exactly five or more reviews/comments, rather than strictly more than five.

Also rewords strings containing comment or review to use both terms as they are both possible and adds pill style to the button.

Close #781