### PR TITLE
build: Specify the minimum required version of libadwaita

### DIFF
--- a/build-aux/com.mattjakeman.ExtensionManager.json
+++ b/build-aux/com.mattjakeman.ExtensionManager.json
@@ -25,7 +25,7 @@
         "*.a"
     ],
     "modules" : [
-    	{
+        {
             "name" : "blueprint-compiler",
             "builddir" : true,
             "buildsystem" : "meson",
@@ -70,8 +70,8 @@
                 {
                     "type" : "git",
                     "url" : "https://github.com/mjakeman/extension-manager",
-                    "commit" : "54585fc15c3fe4939f2ba22ebc8808e6ef46c8f4",
-                    "tag" : "v0.6.1"
+                    "commit" : "b680e30c659a8c7c04533b01f7b4e3154504cffa",
+                    "tag" : "v0.6.2"
                 }
             ]
         }

--- a/src/meson.build
+++ b/src/meson.build
@@ -37,7 +37,7 @@ libbacktrace_dep = cc.find_library('backtrace', required: get_option('backtrace'
 
 exm_deps = [
   dependency('gtk4'),
-  dependency('libadwaita-1'),
+  dependency('libadwaita-1', version: '>= 1.7.0'),
   dependency('gio-unix-2.0'),
   dependency('json-glib-1.0'),
   dependency('libsoup-3.0'),


### PR DESCRIPTION
By setting a minimum version we help to identify more easily what the problem is when trying to build with older versions.

It requires updating every time we use widgets introduced in the latest versions.

We don't need to specify the version of any further dependencies since libadwaita already increments the minimum required version of GTK and we don't depend on anything specific of the latest versions.

Helps #792