### PR TITLE
general: Use g_strcmp0 for null safe string comparison

### DIFF
--- a/src/exm-application.c
+++ b/src/exm-application.c
@@ -140,7 +140,7 @@ exm_application_open (GApplication  *app,
     }
 
     scheme = g_uri_get_scheme (uri);
-    if (!g_str_equal (scheme, "gnome-extensions"))
+    if (g_strcmp0 (scheme, "gnome-extensions") != 0)
     {
         g_critical ("Invalid URI scheme: '%s'\n", scheme);
         return;

--- a/src/exm-window.c
+++ b/src/exm-window.c
@@ -124,7 +124,7 @@ extension_remove_dialog_response (AdwAlertDialog   *dialog,
 {
     const char *response = adw_alert_dialog_choose_finish (dialog, result);
 
-    if (g_str_equal (response, "yes"))
+    if (g_strcmp0 (response, "yes") == 0)
         exm_manager_remove_extension (data->manager, data->extension);
 
     g_clear_pointer (&data->manager, g_object_unref);
@@ -215,7 +215,7 @@ extension_unsupported_dialog_response (AdwAlertDialog        *dialog,
 {
     const char *response = adw_alert_dialog_choose_finish (dialog, result);
 
-    if (g_str_equal (response, "install"))
+    if (g_strcmp0 (response, "install") == 0)
     {
         exm_manager_install_async (data->manager, data->uuid, NULL,
                                    (GAsyncReadyCallback) on_install_done,
@@ -285,7 +285,7 @@ show_view (GtkWidget  *widget,
 
     self = EXM_WINDOW (widget);
 
-    if (g_str_equal (action_name, "win.show-detail"))
+    if (g_strcmp0 (action_name, "win.show-detail") == 0)
     {
         gchar *uuid;
 

--- a/src/local/exm-manager.c
+++ b/src/local/exm-manager.c
@@ -382,11 +382,10 @@ exm_manager_install_finish (GObject       *self,
                                                                      result,
                                                                      error);
 
-    if (g_str_equal (out_result, "cancelled"))
-    {
+    if (g_strcmp0 (out_result, "cancelled") == 0)
         success = FALSE;
-        g_free (out_result);
-    }
+
+    g_free (out_result);
 
     return success;
 }

--- a/src/web/model/exm-shell-version-map.c
+++ b/src/web/model/exm-shell-version-map.c
@@ -134,7 +134,7 @@ exm_shell_version_map_supports (ExmShellVersionMap *self,
     {
         MapEntry *entry = element->data;
 
-        if (!g_str_equal (major, entry->shell_major_version))
+        if (g_strcmp0 (major, entry->shell_major_version) != 0)
             continue;
 
         if (!entry->shell_minor_version ||


### PR DESCRIPTION
Instead of g_str_equal which is still used for hash table comparisons as recommended in the documentation.

Fix #798