### PR TITLE
Add toggle to enable/disable automatic update checking

### DIFF
--- a/data/com.mattjakeman.ExtensionManager.gschema.xml.in
+++ b/data/com.mattjakeman.ExtensionManager.gschema.xml.in
@@ -19,5 +19,10 @@
       <summary>Sort Enabled First</summary>
       <description>Display enabled extensions first in the installed view.</description>
     </key>
+    <key name="auto-check-updates" type="b">
+      <default>true</default>
+      <summary>Auto Check for Updates</summary>
+      <description>Automatically check for extension updates on startup.</description>
+    </key>
   </schema>
 </schemalist>

--- a/po/extension-manager.pot
+++ b/po/extension-manager.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: extension-manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-28 09:43+0000\n"
+"POT-Creation-Date: 2026-02-20 08:59-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -116,7 +116,7 @@ msgstr ""
 msgid "_Load More Results"
 msgstr ""
 
-#: src/exm-browse-page.blp:145 src/exm-installed-page.blp:58
+#: src/exm-browse-page.blp:145 src/exm-installed-page.blp:68
 msgid "No Results Found"
 msgstr ""
 
@@ -348,32 +348,40 @@ msgstr ""
 msgid "Extensions can cause performance and stability issues"
 msgstr ""
 
-#: src/exm-installed-page.blp:35 src/exm-upgrade-assistant.blp:135
+#: src/exm-installed-page.blp:38
+msgid "Auto Check for Updates"
+msgstr ""
+
+#: src/exm-installed-page.blp:39
+msgid "Check for extension updates on startup"
+msgstr ""
+
+#: src/exm-installed-page.blp:45 src/exm-upgrade-assistant.blp:135
 msgid "User-Installed Extensions"
 msgstr ""
 
-#: src/exm-installed-page.blp:40 src/exm-upgrade-assistant.blp:139
+#: src/exm-installed-page.blp:50 src/exm-upgrade-assistant.blp:139
 msgid "System Extensions"
 msgstr ""
 
-#: src/exm-installed-page.blp:59
+#: src/exm-installed-page.blp:69
 msgid "Try a different search or search online"
 msgstr ""
 
-#: src/exm-installed-page.blp:66 src/exm-installed-page.blp:87
+#: src/exm-installed-page.blp:76 src/exm-installed-page.blp:97
 msgid "_Search Online"
 msgstr ""
 
-#: src/exm-installed-page.blp:79 src/exm-upgrade-assistant.c:496
+#: src/exm-installed-page.blp:89 src/exm-upgrade-assistant.c:496
 msgid "No Extensions Installed"
 msgstr ""
 
-#: src/exm-installed-page.blp:80
+#: src/exm-installed-page.blp:90
 msgid "Search online to install extensions"
 msgstr ""
 
 #. Translators: '%d' = number of extensions that will be updated
-#: src/exm-installed-page.c:315
+#: src/exm-installed-page.c:324
 #, c-format
 msgid "%d extension will be updated on next login"
 msgid_plural "%d extensions will be updated on next login"

--- a/src/exm-installed-page.blp
+++ b/src/exm-installed-page.blp
@@ -28,6 +28,16 @@ template $ExmInstalledPage: Gtk.Widget {
             title: _("Use Extensions");
             subtitle: _("Extensions can cause performance and stability issues");
           }
+
+          Adw.SwitchRow auto_check_updates_toggle {
+            [prefix]
+            Gtk.Image {
+              icon-name: 'software-update-available-symbolic';
+            }
+
+            title: _("Auto Check for Updates");
+            subtitle: _("Check for extension updates on startup");
+          }
         }
 
         Adw.PreferencesGroup user_prefs_group {

--- a/src/exm-installed-page.c
+++ b/src/exm-installed-page.c
@@ -40,12 +40,14 @@ struct _ExmInstalledPage
     GtkStack *stack;
     AdwBanner *updates_banner;
     AdwSwitchRow *global_toggle;
+    AdwSwitchRow *auto_check_updates_toggle;
     AdwPreferencesGroup *user_prefs_group;
     AdwPreferencesGroup *system_prefs_group;
     AdwPreferencesGroup *search_prefs_group;
     GtkFilterListModel *search_list_model;
 
     gboolean sort_enabled_first;
+    gboolean auto_check_updates;
     gboolean search_mode_enabled;
     const char *search_query;
     guint signal_id;
@@ -57,6 +59,7 @@ enum {
     PROP_0,
     PROP_MANAGER,
     PROP_SORT_ENABLED_FIRST,
+    PROP_AUTO_CHECK_UPDATES,
     PROP_SEARCH_MODE_ENABLED,
     PROP_SEARCH_QUERY,
     N_PROPS
@@ -104,6 +107,9 @@ exm_installed_page_get_property (GObject    *object,
     case PROP_SORT_ENABLED_FIRST:
         g_value_set_boolean (value, self->sort_enabled_first);
         break;
+    case PROP_AUTO_CHECK_UPDATES:
+        g_value_set_boolean (value, self->auto_check_updates);
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
@@ -125,6 +131,9 @@ exm_installed_page_set_property (GObject      *object,
     case PROP_SORT_ENABLED_FIRST:
         self->sort_enabled_first = g_value_get_boolean (value);
         invalidate_model_bindings (self);
+        break;
+    case PROP_AUTO_CHECK_UPDATES:
+        self->auto_check_updates = g_value_get_boolean (value);
         break;
     case PROP_SEARCH_MODE_ENABLED:
         self->search_mode_enabled = g_value_get_boolean (value);
@@ -450,7 +459,8 @@ on_bind_manager (ExmInstalledPage *self)
     // Check if updates are available
     // NOTE: We need to do this *after* connecting the signal
     // handler above, otherwise we will not be notified.
-    exm_manager_check_for_updates (self->manager);
+    if (self->auto_check_updates)
+        exm_manager_check_for_updates (self->manager);
 }
 
 static void
@@ -476,6 +486,13 @@ exm_installed_page_class_init (ExmInstalledPageClass *klass)
                                 FALSE,
                                 G_PARAM_READWRITE);
 
+    properties [PROP_AUTO_CHECK_UPDATES]
+        = g_param_spec_boolean ("auto-check-updates",
+                                "Auto Check Updates",
+                                "Auto Check Updates",
+                                TRUE,
+                                G_PARAM_READWRITE);
+
     properties [PROP_SEARCH_MODE_ENABLED]
         = g_param_spec_boolean ("search-mode-enabled",
                                 "Search Mode Enabled",
@@ -499,6 +516,7 @@ exm_installed_page_class_init (ExmInstalledPageClass *klass)
     gtk_widget_class_bind_template_child (widget_class, ExmInstalledPage, stack);
     gtk_widget_class_bind_template_child (widget_class, ExmInstalledPage, updates_banner);
     gtk_widget_class_bind_template_child (widget_class, ExmInstalledPage, global_toggle);
+    gtk_widget_class_bind_template_child (widget_class, ExmInstalledPage, auto_check_updates_toggle);
     gtk_widget_class_bind_template_child (widget_class, ExmInstalledPage, user_prefs_group);
     gtk_widget_class_bind_template_child (widget_class, ExmInstalledPage, system_prefs_group);
     gtk_widget_class_bind_template_child (widget_class, ExmInstalledPage, search_prefs_group);
@@ -521,6 +539,14 @@ exm_installed_page_init (ExmInstalledPage *self)
     g_settings_bind (settings, "sort-enabled-first",
                      self, "sort-enabled-first",
                      G_SETTINGS_BIND_GET);
+
+    g_settings_bind (settings, "auto-check-updates",
+                     self, "auto-check-updates",
+                     G_SETTINGS_BIND_DEFAULT);
+
+    g_object_bind_property (self, "auto-check-updates",
+                            self->auto_check_updates_toggle, "active",
+                            G_BINDING_BIDIRECTIONAL|G_BINDING_SYNC_CREATE);
 
     g_object_unref (settings);
 }


### PR DESCRIPTION
## Summary
- Add a new GSettings key `auto-check-updates` (default: `true`) to control whether the app automatically checks for extension updates on startup
- Add an `Adw.SwitchRow` toggle in the Installed page UI, with an icon and translatable strings, bound bidirectionally to the setting
- Wire the `auto-check-updates` property into `ExmInstalledPage` so that `exm_manager_check_for_updates()` is only called when the setting is enabled

## Motivation
Give users greater control over when updates should occur. Users who have found a stable environment can disable automatic update checking to avoid unexpected changes that could disrupt their workflow.

## Changes
| File | Description |
|------|-------------|
| `data/com.mattjakeman.ExtensionManager.gschema.xml.in` | New boolean key `auto-check-updates` (default `true`) |
| `src/exm-installed-page.blp` | New `Adw.SwitchRow` widget with icon and i18n labels |
| `src/exm-installed-page.c` | New `auto-check-updates` property, GSettings/GObject bindings, conditional update check |
| `po/extension-manager.pot` | Updated translation template with new strings |

## Test plan
- [x] Launch the app with the default setting — updates should be checked automatically on startup (existing behavior preserved)
- [x] Toggle "Auto Check for Updates" off, restart the app — updates should not be checked on startup
- [x] Toggle it back on, restart — updates should be checked again
- [x] Verify the setting persists across sessions via `gsettings get com.mattjakeman.ExtensionManager auto-check-updates`
- [x] Verify the toggle appears correctly in the Installed page with the `software-update-available-symbolic` icon

## Note
This is my first contribution to an open-source project. Claude was used as an aid during the development of this feature.
