### PR TITLE
detail-view: Animate GIF screenshots via glycin

### DIFF
--- a/src/exm-animated-paintable.c
+++ b/src/exm-animated-paintable.c
@@ -1,0 +1,191 @@
+/*
+ * exm-animated-paintable.c
+ *
+ * Copyright 2022-2026 Matthew Jakeman <mjakeman26@outlook.co.nz>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "exm-animated-paintable.h"
+
+#include <glycin-gtk4.h>
+
+struct _ExmAnimatedPaintable
+{
+    GObject parent_instance;
+
+    GlyImage *image;
+    GdkTexture *current_frame;
+    GCancellable *cancellable;
+    guint timeout_id;
+};
+
+static void exm_animated_paintable_paintable_init (GdkPaintableInterface *iface);
+
+G_DEFINE_FINAL_TYPE_WITH_CODE (ExmAnimatedPaintable, exm_animated_paintable, G_TYPE_OBJECT,
+                               G_IMPLEMENT_INTERFACE (GDK_TYPE_PAINTABLE, exm_animated_paintable_paintable_init))
+
+static gboolean on_timeout (gpointer user_data);
+
+static void
+schedule_next_frame (ExmAnimatedPaintable *self,
+                     gint64                 delay_us)
+{
+    g_clear_handle_id (&self->timeout_id, g_source_remove);
+
+    // A non-positive delay means the animation has no more frames to show
+    if (delay_us <= 0)
+        return;
+
+    self->timeout_id = g_timeout_add (delay_us / 1000, on_timeout, self);
+}
+
+static void
+on_next_frame (GObject      *source,
+               GAsyncResult *res,
+               gpointer      user_data)
+{
+    ExmAnimatedPaintable *self = EXM_ANIMATED_PAINTABLE (user_data);
+    GError *error = NULL;
+    GlyFrame *frame = gly_image_next_frame_finish (GLY_IMAGE (source), res, &error);
+
+    if (error)
+    {
+        if (!g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
+            g_warning ("Could not load next GIF frame: %s\n", error->message);
+
+        g_error_free (error);
+        g_object_unref (self);
+        return;
+    }
+
+    g_clear_object (&self->current_frame);
+    self->current_frame = gly_gtk_frame_get_texture (frame);
+
+    gint64 delay_us = gly_frame_get_delay (frame);
+    g_object_unref (frame);
+
+    gdk_paintable_invalidate_contents (GDK_PAINTABLE (self));
+    schedule_next_frame (self, delay_us);
+
+    g_object_unref (self);
+}
+
+static gboolean
+on_timeout (gpointer user_data)
+{
+    ExmAnimatedPaintable *self = EXM_ANIMATED_PAINTABLE (user_data);
+
+    self->timeout_id = 0;
+
+    // Keep self alive for the duration of the request; released in on_next_frame
+    gly_image_next_frame_async (self->image, self->cancellable, on_next_frame, g_object_ref (self));
+
+    return G_SOURCE_REMOVE;
+}
+
+ExmAnimatedPaintable *
+exm_animated_paintable_new (GlyImage   *image,
+                            GdkTexture *first_frame,
+                            gint64      delay_us)
+{
+    ExmAnimatedPaintable *self;
+
+    g_return_val_if_fail (GLY_IS_IMAGE (image), NULL);
+    g_return_val_if_fail (GDK_IS_TEXTURE (first_frame), NULL);
+
+    self = g_object_new (EXM_TYPE_ANIMATED_PAINTABLE, NULL);
+
+    self->image = image;
+    self->current_frame = first_frame;
+    self->cancellable = g_cancellable_new ();
+
+    schedule_next_frame (self, delay_us);
+
+    return self;
+}
+
+static void
+exm_animated_paintable_snapshot (GdkPaintable *paintable,
+                                 GdkSnapshot  *snapshot,
+                                 double        width,
+                                 double        height)
+{
+    ExmAnimatedPaintable *self = EXM_ANIMATED_PAINTABLE (paintable);
+
+    if (self->current_frame)
+        gdk_paintable_snapshot (GDK_PAINTABLE (self->current_frame), snapshot, width, height);
+}
+
+static int
+exm_animated_paintable_get_intrinsic_width (GdkPaintable *paintable)
+{
+    ExmAnimatedPaintable *self = EXM_ANIMATED_PAINTABLE (paintable);
+
+    return gdk_texture_get_width (self->current_frame);
+}
+
+static int
+exm_animated_paintable_get_intrinsic_height (GdkPaintable *paintable)
+{
+    ExmAnimatedPaintable *self = EXM_ANIMATED_PAINTABLE (paintable);
+
+    return gdk_texture_get_height (self->current_frame);
+}
+
+static GdkPaintableFlags
+exm_animated_paintable_get_flags (GdkPaintable *paintable G_GNUC_UNUSED)
+{
+    return GDK_PAINTABLE_STATIC_SIZE;
+}
+
+static void
+exm_animated_paintable_paintable_init (GdkPaintableInterface *iface)
+{
+    iface->snapshot = exm_animated_paintable_snapshot;
+    iface->get_intrinsic_width = exm_animated_paintable_get_intrinsic_width;
+    iface->get_intrinsic_height = exm_animated_paintable_get_intrinsic_height;
+    iface->get_flags = exm_animated_paintable_get_flags;
+}
+
+static void
+exm_animated_paintable_dispose (GObject *object)
+{
+    ExmAnimatedPaintable *self = (ExmAnimatedPaintable *)object;
+
+    if (self->cancellable)
+        g_cancellable_cancel (self->cancellable);
+
+    g_clear_handle_id (&self->timeout_id, g_source_remove);
+    g_clear_object (&self->current_frame);
+    g_clear_object (&self->image);
+    g_clear_object (&self->cancellable);
+
+    G_OBJECT_CLASS (exm_animated_paintable_parent_class)->dispose (object);
+}
+
+static void
+exm_animated_paintable_class_init (ExmAnimatedPaintableClass *klass)
+{
+    GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+    object_class->dispose = exm_animated_paintable_dispose;
+}
+
+static void
+exm_animated_paintable_init (ExmAnimatedPaintable *self G_GNUC_UNUSED)
+{
+}

--- a/src/exm-animated-paintable.h
+++ b/src/exm-animated-paintable.h
@@ -1,0 +1,37 @@
+/*
+ * exm-animated-paintable.h
+ *
+ * Copyright 2022-2026 Matthew Jakeman <mjakeman26@outlook.co.nz>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <gdk/gdk.h>
+#include <glycin.h>
+
+G_BEGIN_DECLS
+
+#define EXM_TYPE_ANIMATED_PAINTABLE (exm_animated_paintable_get_type())
+
+G_DECLARE_FINAL_TYPE (ExmAnimatedPaintable, exm_animated_paintable, EXM, ANIMATED_PAINTABLE, GObject)
+
+ExmAnimatedPaintable *exm_animated_paintable_new (GlyImage   *image,
+                                                  GdkTexture *first_frame,
+                                                  gint64      delay_us);
+
+G_END_DECLS

--- a/src/exm-detail-view.c
+++ b/src/exm-detail-view.c
@@ -1,7 +1,7 @@
 /*
  * exm-detail-view.c
  *
- * Copyright 2022-2025 Matthew Jakeman <mjakeman26@outlook.co.nz>
+ * Copyright 2022-2026 Matthew Jakeman <mjakeman26@outlook.co.nz>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -168,8 +168,8 @@ on_icon_loaded (GObject       *source,
                 ExmDetailView *self)
 {
     GError *error = NULL;
-    GdkTexture *texture = exm_image_resolver_resolve_finish (EXM_IMAGE_RESOLVER (source),
-                                                             res, &error);
+    GdkPaintable *paintable = exm_image_resolver_resolve_finish (EXM_IMAGE_RESOLVER (source),
+                                                                  res, &error);
 
     if (error)
     {
@@ -178,8 +178,8 @@ on_icon_loaded (GObject       *source,
         return;
     }
 
-    gtk_image_set_from_paintable (self->ext_icon, GDK_PAINTABLE (texture));
-    g_object_unref (texture);
+    gtk_image_set_from_paintable (self->ext_icon, paintable);
+    g_object_unref (paintable);
     g_object_unref (self);
 }
 
@@ -189,8 +189,8 @@ on_image_loaded (GObject       *source,
                  ExmDetailView *self)
 {
     GError *error = NULL;
-    GdkTexture *texture = exm_image_resolver_resolve_finish (EXM_IMAGE_RESOLVER (source),
-                                                             res, &error);
+    GdkPaintable *paintable = exm_image_resolver_resolve_finish (EXM_IMAGE_RESOLVER (source),
+                                                                  res, &error);
 
     if (error)
     {
@@ -199,10 +199,10 @@ on_image_loaded (GObject       *source,
         return;
     }
 
-    g_object_set (self, "screenshot", GDK_PAINTABLE (texture), NULL);
-    exm_screenshot_set_paintable (self->ext_screenshot, GDK_PAINTABLE (texture));
+    g_object_set (self, "screenshot", paintable, NULL);
+    exm_screenshot_set_paintable (self->ext_screenshot, paintable);
     exm_screenshot_display (self->ext_screenshot);
-    g_object_unref (texture);
+    g_object_unref (paintable);
     g_object_unref (self);
 
     gtk_widget_set_visible (GTK_WIDGET (self->ext_screenshot_popout_button), TRUE);

--- a/src/exm-zoom-picture.c
+++ b/src/exm-zoom-picture.c
@@ -1,7 +1,7 @@
 /*
  * exm-zoom-picture.c
  *
- * Copyright 2022-2025 Matthew Jakeman <mjakeman26@outlook.co.nz>
+ * Copyright 2022-2026 Matthew Jakeman <mjakeman26@outlook.co.nz>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,6 +26,8 @@ struct _ExmZoomPicture
 	GtkWidget parent_instance;
 
 	GdkPaintable *paintable;
+	gulong invalidate_contents_id;
+	gulong invalidate_size_id;
 	GtkGesture *zoom;
 	GtkGesture *drag;
 
@@ -104,15 +106,39 @@ exm_zoom_picture_set_property (GObject      *object,
     }
 }
 
+static void
+on_paintable_invalidate_contents (GdkPaintable   *paintable G_GNUC_UNUSED,
+                                  ExmZoomPicture *self)
+{
+	gtk_widget_queue_draw (GTK_WIDGET (self));
+}
+
+static void
+on_paintable_invalidate_size (GdkPaintable   *paintable G_GNUC_UNUSED,
+                              ExmZoomPicture *self)
+{
+	gtk_widget_queue_resize (GTK_WIDGET (self));
+}
+
 void
 exm_zoom_picture_set_paintable (ExmZoomPicture *self,
                                 GdkPaintable   *paintable)
 {
 	if (self->paintable)
-		g_object_unref (paintable);
+	{
+		g_signal_handler_disconnect (self->paintable, self->invalidate_contents_id);
+		g_signal_handler_disconnect (self->paintable, self->invalidate_size_id);
+		g_clear_object (&self->paintable);
+	}
 
 	if (paintable)
+	{
 		self->paintable = g_object_ref (paintable);
+		self->invalidate_contents_id = g_signal_connect (paintable, "invalidate-contents",
+		                                                  G_CALLBACK (on_paintable_invalidate_contents), self);
+		self->invalidate_size_id = g_signal_connect (paintable, "invalidate-size",
+		                                             G_CALLBACK (on_paintable_invalidate_size), self);
+	}
 
 	gtk_widget_queue_draw (GTK_WIDGET (self));
 }
@@ -231,10 +257,21 @@ exm_zoom_picture_snapshot (GtkWidget   *widget,
 }
 
 static void
+exm_zoom_picture_dispose (GObject *object)
+{
+	ExmZoomPicture *self = (ExmZoomPicture *)object;
+
+	exm_zoom_picture_set_paintable (self, NULL);
+
+	G_OBJECT_CLASS (exm_zoom_picture_parent_class)->dispose (object);
+}
+
+static void
 exm_zoom_picture_class_init (ExmZoomPictureClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS (klass);
 
+	object_class->dispose = exm_zoom_picture_dispose;
 	object_class->get_property = exm_zoom_picture_get_property;
 	object_class->set_property = exm_zoom_picture_set_property;
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,6 +7,7 @@ exm_sources = [
   'exm-detail-view.c',
   'exm-screenshot.c',
   'exm-zoom-picture.c',
+  'exm-animated-paintable.c',
   'exm-comment-tile.c',
   'exm-comment-dialog.c',
   'exm-rating.c',
@@ -42,6 +43,8 @@ exm_deps = [
   dependency('json-glib-1.0'),
   dependency('libsoup-3.0'),
   dependency('libxml-2.0'),
+  dependency('glycin-2'),
+  dependency('glycin-gtk4-2'),
 ]
 
 if libbacktrace_dep.found()

--- a/src/web/exm-image-resolver.c
+++ b/src/web/exm-image-resolver.c
@@ -1,7 +1,7 @@
 /*
  * exm-image-resolver.c
  *
- * Copyright 2022-2025 Matthew Jakeman <mjakeman26@outlook.co.nz>
+ * Copyright 2022-2026 Matthew Jakeman <mjakeman26@outlook.co.nz>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,7 +21,11 @@
 
 #include "exm-image-resolver.h"
 
+#include "exm-animated-paintable.h"
+
 #include <libsoup/soup.h>
+#include <glycin.h>
+#include <glycin-gtk4.h>
 
 struct _ExmImageResolver
 {
@@ -50,14 +54,87 @@ exm_image_resolver_finalize (GObject *object)
     G_OBJECT_CLASS (exm_image_resolver_parent_class)->finalize (object);
 }
 
+typedef struct
+{
+    GTask *task;
+    GlyImage *image;
+} FrameLoadCtx;
+
+static void
+frame_load_ctx_free (FrameLoadCtx *ctx)
+{
+    g_clear_object (&ctx->image);
+    g_free (ctx);
+}
+
+static void
+on_first_frame_loaded (GObject      *source,
+                       GAsyncResult *res,
+                       gpointer      user_data)
+{
+    FrameLoadCtx *ctx = user_data;
+    GTask *task = ctx->task;
+    GError *error = NULL;
+    GlyFrame *frame = gly_image_next_frame_finish (GLY_IMAGE (source), res, &error);
+
+    if (error)
+    {
+        g_task_return_error (task, error);
+        frame_load_ctx_free (ctx);
+        g_object_unref (task);
+        return;
+    }
+
+    GdkTexture *texture = gly_gtk_frame_get_texture (frame);
+    gint64 delay_us = gly_frame_get_delay (frame);
+    g_object_unref (frame);
+
+    if (delay_us > 0)
+    {
+        GdkPaintable *paintable = GDK_PAINTABLE (exm_animated_paintable_new (ctx->image, texture, delay_us));
+        ctx->image = NULL;
+        g_task_return_pointer (task, paintable, g_object_unref);
+    }
+    else
+    {
+        g_task_return_pointer (task, texture, g_object_unref);
+    }
+
+    frame_load_ctx_free (ctx);
+    g_object_unref (task);
+}
+
+static void
+on_loader_loaded (GObject      *source,
+                  GAsyncResult *res,
+                  gpointer      user_data)
+{
+    GTask *task = G_TASK (user_data);
+    GError *error = NULL;
+    GlyImage *image = gly_loader_load_finish (GLY_LOADER (source), res, &error);
+    FrameLoadCtx *ctx;
+
+    if (error)
+    {
+        g_task_return_error (task, error);
+        g_object_unref (task);
+        return;
+    }
+
+    ctx = g_new0 (FrameLoadCtx, 1);
+    ctx->task = task;
+    ctx->image = image;
+
+    gly_image_next_frame_async (image, g_task_get_cancellable (task), on_first_frame_loaded, ctx);
+}
+
 static void
 image_loaded_callback (GObject      *source,
                        GAsyncResult *res,
                        GTask        *task)
 {
     GBytes *bytes;
-    GdkTexture *texture;
-
+    GlyLoader *loader;
     GError *error = NULL;
 
     bytes = soup_session_send_and_read_finish (SOUP_SESSION (source), res, &error);
@@ -65,21 +142,15 @@ image_loaded_callback (GObject      *source,
     if (error)
     {
         g_task_return_error (task, error);
-    }
-    else
-    {
-        texture = gdk_texture_new_from_bytes (bytes, &error);
-
-        if (error)
-        {
-            g_task_return_error (task, error);
-        }
-
-        g_task_return_pointer (task, texture, g_object_unref);
-        g_bytes_unref (bytes);
+        g_object_unref (task);
+        return;
     }
 
-    g_object_unref (task);
+    loader = gly_loader_new_for_bytes (bytes);
+    g_bytes_unref (bytes);
+
+    gly_loader_load_async (loader, g_task_get_cancellable (task), on_loader_loaded, task);
+    g_object_unref (loader);
 }
 
 void
@@ -125,7 +196,7 @@ exm_image_resolver_resolve_async (ExmImageResolver    *self,
     g_object_unref (msg);
 }
 
-GdkTexture *
+GdkPaintable *
 exm_image_resolver_resolve_finish (ExmImageResolver  *self,
                                    GAsyncResult      *result,
                                    GError           **error)

--- a/src/web/exm-image-resolver.h
+++ b/src/web/exm-image-resolver.h
@@ -1,7 +1,7 @@
 /*
  * exm-image-resolver.h
  *
- * Copyright 2022-2025 Matthew Jakeman <mjakeman26@outlook.co.nz>
+ * Copyright 2022-2026 Matthew Jakeman <mjakeman26@outlook.co.nz>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -37,8 +37,8 @@ void exm_image_resolver_resolve_async (ExmImageResolver    *self,
                                        GCancellable        *cancellable,
                                        GAsyncReadyCallback  callback,
                                        gpointer             user_data);
-GdkTexture *exm_image_resolver_resolve_finish (ExmImageResolver  *self,
-                                               GAsyncResult      *result,
-                                               GError           **error);
+GdkPaintable *exm_image_resolver_resolve_finish (ExmImageResolver  *self,
+                                                 GAsyncResult      *result,
+                                                 GError           **error);
 
 G_END_DECLS


### PR DESCRIPTION
Route screenshot and icon loading through glycin instead of decoding raw bytes into a single GdkTexture, so multi-frame GIFs play back in the detail view.

Fix #410