### PR TITLE
search-provider: Add search provider for installed extensions

### DIFF
--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -27,8 +27,8 @@ jobs:
         run: |
           apt update
           apt install -y git meson gcc gettext cmake appstream desktop-file-utils \
-            libadwaita-1-dev libgtk-4-dev libjson-glib-dev libsoup-3.0-dev libxml2-dev \
-            blueprint-compiler
+            libadwaita-1-dev libglycin-2-dev libglycin-gtk4-2-dev libgtk-4-dev \
+            libjson-glib-dev libsoup-3.0-dev libxml2-dev blueprint-compiler
 
       - name: Setup Repository
         run: |

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Extension Manager needs a recent version of the GNOME SDK in order to build. See
 ### Dependencies
 Extension Manager depends on the following libraries:
  - gettext
+ - glycin (and glycin-gtk4)
  - gtk4
  - libadwaita
  - libjson-glib
@@ -112,7 +113,7 @@ Extension Manager depends on the following libraries:
 
 On Debian-based distributions, the required dependencies can be installed with the following command:
 ```shell
-sudo apt install blueprint-compiler gettext libadwaita-1-dev libgtk-4-dev libjson-glib-dev libsoup-3.0-dev libxml2-dev meson
+sudo apt install blueprint-compiler gettext libadwaita-1-dev libglycin-2-dev libglycin-gtk4-2-dev libgtk-4-dev libjson-glib-dev libsoup-3.0-dev libxml2-dev meson
 ```
 
 ### Building From Source

--- a/data/com.mattjakeman.ExtensionManager.desktop.in.in
+++ b/data/com.mattjakeman.ExtensionManager.desktop.in.in
@@ -8,6 +8,7 @@ Categories=GTK;Utility
 OnlyShowIn=GNOME;
 StartupNotify=true
 MimeType=x-scheme-handler/gnome-extensions;
+DBusActivatable=true
 Comment=Manage GNOME Shell Extensions
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons. The list MUST also end with a semicolon.
 # Make sure to leave the original strings and add your translations afterwards, so that users can search both in English and your language.

--- a/data/com.mattjakeman.ExtensionManager.search-provider.ini.in
+++ b/data/com.mattjakeman.ExtensionManager.search-provider.ini.in
@@ -1,0 +1,5 @@
+[Shell Search Provider]
+DesktopId=@app_id@.desktop
+BusName=@app_id@
+ObjectPath=@app_id_path@/SearchProvider
+Version=2

--- a/data/com.mattjakeman.ExtensionManager.service.in
+++ b/data/com.mattjakeman.ExtensionManager.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=@app_id@
+Exec=@bindir@/extension-manager --gapplication-service

--- a/data/meson.build
+++ b/data/meson.build
@@ -65,4 +65,24 @@ if compile_schemas.found()
   )
 endif
 
+search_provider_conf = configuration_data()
+search_provider_conf.set('app_id', app_id)
+search_provider_conf.set('app_id_path', '/' + app_id.replace('.', '/'))
+configure_file(
+  input: 'com.mattjakeman.ExtensionManager.search-provider.ini.in',
+  output: '@0@.search-provider.ini'.format(app_id),
+  configuration: search_provider_conf,
+  install_dir: join_paths(get_option('datadir'), 'gnome-shell', 'search-providers')
+)
+
+dbus_service_conf = configuration_data()
+dbus_service_conf.set('app_id', app_id)
+dbus_service_conf.set('bindir', join_paths(get_option('prefix'), get_option('bindir')))
+configure_file(
+  input: 'com.mattjakeman.ExtensionManager.service.in',
+  output: '@0@.service'.format(app_id),
+  configuration: dbus_service_conf,
+  install_dir: join_paths(get_option('datadir'), 'dbus-1', 'services')
+)
+
 subdir('icons')

--- a/src/exm-application.c
+++ b/src/exm-application.c
@@ -22,6 +22,7 @@
 #include "exm-config.h"
 
 #include "exm-application.h"
+#include "exm-gnome-shell-search-provider.h"
 #include "exm-window.h"
 
 #include "exm-utils.h"
@@ -31,6 +32,9 @@
 struct _ExmApplication
 {
     AdwApplication parent_instance;
+
+    ExmManager *manager;
+    ExmGnomeShellSearchProvider *search_provider;
 };
 
 G_DEFINE_TYPE (ExmApplication, exm_application, ADW_TYPE_APPLICATION)
@@ -45,6 +49,14 @@ exm_application_new (gchar             *application_id,
                          NULL);
 }
 
+ExmManager *
+exm_application_get_manager (ExmApplication *self)
+{
+    g_return_val_if_fail (EXM_IS_APPLICATION (self), NULL);
+
+    return self->manager;
+}
+
 static ExmWindow *
 get_current_window (GApplication *app)
 {
@@ -56,6 +68,7 @@ get_current_window (GApplication *app)
     if (window == NULL)
         window = g_object_new (EXM_TYPE_WINDOW,
                                "application", app,
+                               "manager", exm_application_get_manager (EXM_APPLICATION (app)),
                                NULL);
 
     settings = g_settings_new (APP_ID);
@@ -138,10 +151,54 @@ exm_application_open (GApplication  *app,
 }
 
 
+static gboolean
+exm_application_dbus_register (GApplication     *application,
+                               GDBusConnection  *connection,
+                               const gchar      *object_path,
+                               GError          **error)
+{
+    ExmApplication *self = EXM_APPLICATION (application);
+    g_autofree gchar *search_provider_path = NULL;
+
+    if (!G_APPLICATION_CLASS (exm_application_parent_class)->dbus_register (application, connection, object_path, error))
+        return FALSE;
+
+    search_provider_path = g_strdup_printf ("%s/SearchProvider", object_path);
+
+    return exm_gnome_shell_search_provider_export (self->search_provider, connection,
+                                                    search_provider_path, error);
+}
+
+static void
+exm_application_dbus_unregister (GApplication    *application,
+                                 GDBusConnection *connection,
+                                 const gchar     *object_path)
+{
+    ExmApplication *self = EXM_APPLICATION (application);
+
+    exm_gnome_shell_search_provider_unexport (self->search_provider);
+
+    G_APPLICATION_CLASS (exm_application_parent_class)->dbus_unregister (application, connection, object_path);
+}
+
+static void
+exm_application_dispose (GObject *object)
+{
+    ExmApplication *self = EXM_APPLICATION (object);
+
+    g_clear_object (&self->search_provider);
+    g_clear_object (&self->manager);
+
+    G_OBJECT_CLASS (exm_application_parent_class)->dispose (object);
+}
+
 static void
 exm_application_class_init (ExmApplicationClass *klass)
 {
+    GObjectClass *object_class = G_OBJECT_CLASS (klass);
     GApplicationClass *app_class = G_APPLICATION_CLASS (klass);
+
+    object_class->dispose = exm_application_dispose;
 
     /*
     * We connect to the activate callback to create a window when the application
@@ -151,6 +208,8 @@ exm_application_class_init (ExmApplicationClass *klass)
     */
     app_class->activate = exm_application_activate;
     app_class->open = exm_application_open;
+    app_class->dbus_register = exm_application_dbus_register;
+    app_class->dbus_unregister = exm_application_dbus_unregister;
 }
 
 static void
@@ -220,6 +279,9 @@ static void
 exm_application_init (ExmApplication *self)
 {
     GSettings *settings = g_settings_new (APP_ID);
+
+    self->manager = exm_manager_new ();
+    self->search_provider = exm_gnome_shell_search_provider_new (self->manager);
 
     GSimpleAction *quit_action = g_simple_action_new ("quit", NULL);
     g_signal_connect_swapped (quit_action, "activate", G_CALLBACK (g_application_quit), self);

--- a/src/exm-application.h
+++ b/src/exm-application.h
@@ -23,6 +23,8 @@
 
 #include <adwaita.h>
 
+#include "local/exm-manager.h"
+
 G_BEGIN_DECLS
 
 #define EXM_TYPE_APPLICATION (exm_application_get_type())
@@ -31,5 +33,7 @@ G_DECLARE_FINAL_TYPE (ExmApplication, exm_application, EXM, APPLICATION, AdwAppl
 
 ExmApplication *exm_application_new (gchar             *application_id,
                                      GApplicationFlags  flags);
+
+ExmManager     *exm_application_get_manager (ExmApplication *self);
 
 G_END_DECLS

--- a/src/exm-gnome-shell-search-provider.c
+++ b/src/exm-gnome-shell-search-provider.c
@@ -1,0 +1,328 @@
+/*
+ * exm-gnome-shell-search-provider.c
+ *
+ * Copyright 2022-2026 Matthew Jakeman <mjakeman26@outlook.co.nz>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "exm-gnome-shell-search-provider.h"
+
+#include <gtk/gtk.h>
+
+#include "exm-config.h"
+#include "exm-shell-search-provider-generated.h"
+
+struct _ExmGnomeShellSearchProvider
+{
+    GObject parent_instance;
+
+    ExmManager *manager;
+
+    ExmShellSearchProvider2 *skeleton;
+    GDBusConnection *connection;
+    gchar *object_path;
+};
+
+G_DEFINE_FINAL_TYPE (ExmGnomeShellSearchProvider, exm_gnome_shell_search_provider, G_TYPE_OBJECT)
+
+static gboolean
+extension_matches_terms (ExmExtension       *extension,
+                         const gchar *const *terms)
+{
+    gchar *name = NULL;
+    gchar *description = NULL;
+    gchar *uuid = NULL;
+    gboolean matches = TRUE;
+
+    g_object_get (extension,
+                 "name", &name,
+                 "description", &description,
+                 "uuid", &uuid,
+                 NULL);
+
+    for (int i = 0; matches && terms[i] != NULL; i++)
+    {
+        g_autofree gchar *term_folded = g_utf8_casefold (terms[i], -1);
+        gboolean term_matches = FALSE;
+
+        if (name != NULL)
+        {
+            g_autofree gchar *name_folded = g_utf8_casefold (name, -1);
+            term_matches = (strstr (name_folded, term_folded) != NULL);
+        }
+
+        if (!term_matches && description != NULL)
+        {
+            g_autofree gchar *description_folded = g_utf8_casefold (description, -1);
+            term_matches = (strstr (description_folded, term_folded) != NULL);
+        }
+
+        if (!term_matches && uuid != NULL)
+        {
+            g_autofree gchar *uuid_folded = g_utf8_casefold (uuid, -1);
+            term_matches = (strstr (uuid_folded, term_folded) != NULL);
+        }
+
+        matches = term_matches;
+    }
+
+    g_free (name);
+    g_free (description);
+    g_free (uuid);
+
+    return matches;
+}
+
+static GVariant *
+find_matching_results (ExmGnomeShellSearchProvider *self,
+                       const gchar *const          *terms)
+{
+    GVariantBuilder builder;
+    GListModel *model = NULL;
+    guint n_items;
+
+    g_variant_builder_init (&builder, G_VARIANT_TYPE ("as"));
+
+    g_object_get (self->manager, "extensions", &model, NULL);
+
+    n_items = model ? g_list_model_get_n_items (model) : 0;
+    for (guint i = 0; i < n_items; i++)
+    {
+        g_autoptr (ExmExtension) extension = g_list_model_get_item (model, i);
+        gboolean has_prefs = FALSE;
+
+        g_object_get (extension, "has-prefs", &has_prefs, NULL);
+
+        if (has_prefs && extension_matches_terms (extension, terms))
+        {
+            gchar *uuid = NULL;
+            g_object_get (extension, "uuid", &uuid, NULL);
+            g_variant_builder_add (&builder, "s", uuid);
+            g_free (uuid);
+        }
+    }
+
+    g_clear_object (&model);
+
+    return g_variant_new ("(as)", &builder);
+}
+
+static gboolean
+handle_get_initial_result_set (ExmShellSearchProvider2      *skeleton G_GNUC_UNUSED,
+                               GDBusMethodInvocation        *invocation,
+                               gchar                        **terms,
+                               ExmGnomeShellSearchProvider  *self)
+{
+    g_dbus_method_invocation_return_value (invocation,
+                                           find_matching_results (self, (const gchar *const *) terms));
+    return TRUE;
+}
+
+static gboolean
+handle_get_subsearch_result_set (ExmShellSearchProvider2      *skeleton G_GNUC_UNUSED,
+                                 GDBusMethodInvocation        *invocation,
+                                 gchar                        **previous_results G_GNUC_UNUSED,
+                                 gchar                        **terms,
+                                 ExmGnomeShellSearchProvider  *self)
+{
+    g_dbus_method_invocation_return_value (invocation,
+                                           find_matching_results (self, (const gchar *const *) terms));
+    return TRUE;
+}
+
+static gboolean
+handle_get_result_metas (ExmShellSearchProvider2      *skeleton G_GNUC_UNUSED,
+                         GDBusMethodInvocation        *invocation,
+                         gchar                        **results,
+                         ExmGnomeShellSearchProvider  *self)
+{
+    GVariantBuilder builder;
+
+    g_variant_builder_init (&builder, G_VARIANT_TYPE ("aa{sv}"));
+
+    for (int i = 0; results[i] != NULL; i++)
+    {
+        ExmExtension *extension = exm_manager_get_by_uuid (self->manager, results[i]);
+        GVariantBuilder meta_builder;
+        gchar *name = NULL;
+        gchar *description = NULL;
+        g_autoptr (GIcon) icon = NULL;
+        GVariant *icon_variant = NULL;
+
+        if (extension == NULL)
+            continue;
+
+        g_object_get (extension, "name", &name, "description", &description, NULL);
+
+        g_variant_builder_init (&meta_builder, G_VARIANT_TYPE ("a{sv}"));
+        g_variant_builder_add (&meta_builder, "{sv}", "id", g_variant_new_string (results[i]));
+        g_variant_builder_add (&meta_builder, "{sv}", "name", g_variant_new_string (name ? name : results[i]));
+
+        if (description != NULL && *description != '\0')
+            g_variant_builder_add (&meta_builder, "{sv}", "description", g_variant_new_string (description));
+
+        icon = g_themed_icon_new (APP_ID);
+        icon_variant = g_icon_serialize (icon);
+        if (icon_variant != NULL)
+            g_variant_builder_add (&meta_builder, "{sv}", "icon", icon_variant);
+
+        g_variant_builder_add_value (&builder, g_variant_builder_end (&meta_builder));
+
+        g_free (name);
+        g_free (description);
+    }
+
+    g_dbus_method_invocation_return_value (invocation, g_variant_new ("(aa{sv})", &builder));
+    return TRUE;
+}
+
+static gboolean
+release_application_hold (gpointer application)
+{
+    g_application_release (G_APPLICATION (application));
+    return G_SOURCE_REMOVE;
+}
+
+static gboolean
+handle_activate_result (ExmShellSearchProvider2      *skeleton,
+                        GDBusMethodInvocation        *invocation,
+                        gchar                        *result,
+                        gchar                        **terms G_GNUC_UNUSED,
+                        guint32                        timestamp G_GNUC_UNUSED,
+                        ExmGnomeShellSearchProvider  *self)
+{
+    ExmExtension *extension;
+
+    extension = exm_manager_get_by_uuid (self->manager, result);
+
+    if (extension != NULL)
+    {
+        GApplication *application = g_application_get_default ();
+        g_application_hold (application);
+        g_timeout_add_seconds (2, release_application_hold, application);
+
+        exm_manager_open_prefs (self->manager, extension);
+    }
+
+    exm_shell_search_provider2_complete_activate_result (skeleton, invocation);
+    return TRUE;
+}
+
+static gboolean
+handle_launch_search (ExmShellSearchProvider2      *skeleton,
+                      GDBusMethodInvocation        *invocation,
+                      gchar                        **terms,
+                      guint32                        timestamp G_GNUC_UNUSED,
+                      ExmGnomeShellSearchProvider  *self G_GNUC_UNUSED)
+{
+    GApplication *application;
+    GtkWindow *window;
+
+    application = g_application_get_default ();
+    g_application_activate (application);
+
+    window = gtk_application_get_active_window (GTK_APPLICATION (application));
+    if (window != NULL)
+    {
+        g_autofree gchar *search_text = g_strjoinv (" ", terms);
+        gtk_widget_activate_action (GTK_WIDGET (window), "win.search-installed", "s", search_text);
+    }
+
+    exm_shell_search_provider2_complete_launch_search (skeleton, invocation);
+    return TRUE;
+}
+
+ExmGnomeShellSearchProvider *
+exm_gnome_shell_search_provider_new (ExmManager *manager)
+{
+    ExmGnomeShellSearchProvider *self;
+
+    self = g_object_new (EXM_TYPE_GNOME_SHELL_SEARCH_PROVIDER, NULL);
+    self->manager = g_object_ref (manager);
+
+    return self;
+}
+
+gboolean
+exm_gnome_shell_search_provider_export (ExmGnomeShellSearchProvider  *self,
+                                        GDBusConnection              *connection,
+                                        const gchar                  *object_path,
+                                        GError                      **error)
+{
+    g_return_val_if_fail (EXM_IS_GNOME_SHELL_SEARCH_PROVIDER (self), FALSE);
+
+    if (!g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON (self->skeleton),
+                                           connection, object_path, error))
+        return FALSE;
+
+    self->connection = g_object_ref (connection);
+    self->object_path = g_strdup (object_path);
+
+    return TRUE;
+}
+
+void
+exm_gnome_shell_search_provider_unexport (ExmGnomeShellSearchProvider *self)
+{
+    g_return_if_fail (EXM_IS_GNOME_SHELL_SEARCH_PROVIDER (self));
+
+    if (self->connection == NULL)
+        return;
+
+    g_dbus_interface_skeleton_unexport (G_DBUS_INTERFACE_SKELETON (self->skeleton));
+
+    g_clear_object (&self->connection);
+    g_clear_pointer (&self->object_path, g_free);
+}
+
+static void
+exm_gnome_shell_search_provider_dispose (GObject *object)
+{
+    ExmGnomeShellSearchProvider *self = EXM_GNOME_SHELL_SEARCH_PROVIDER (object);
+
+    exm_gnome_shell_search_provider_unexport (self);
+
+    g_clear_object (&self->manager);
+    g_clear_object (&self->skeleton);
+
+    G_OBJECT_CLASS (exm_gnome_shell_search_provider_parent_class)->dispose (object);
+}
+
+static void
+exm_gnome_shell_search_provider_class_init (ExmGnomeShellSearchProviderClass *klass)
+{
+    GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+    object_class->dispose = exm_gnome_shell_search_provider_dispose;
+}
+
+static void
+exm_gnome_shell_search_provider_init (ExmGnomeShellSearchProvider *self)
+{
+    self->skeleton = exm_shell_search_provider2_skeleton_new ();
+
+    g_signal_connect (self->skeleton, "handle-get-initial-result-set",
+                      G_CALLBACK (handle_get_initial_result_set), self);
+    g_signal_connect (self->skeleton, "handle-get-subsearch-result-set",
+                      G_CALLBACK (handle_get_subsearch_result_set), self);
+    g_signal_connect (self->skeleton, "handle-get-result-metas",
+                      G_CALLBACK (handle_get_result_metas), self);
+    g_signal_connect (self->skeleton, "handle-activate-result",
+                      G_CALLBACK (handle_activate_result), self);
+    g_signal_connect (self->skeleton, "handle-launch-search",
+                      G_CALLBACK (handle_launch_search), self);
+}

--- a/src/exm-gnome-shell-search-provider.h
+++ b/src/exm-gnome-shell-search-provider.h
@@ -1,0 +1,43 @@
+/*
+ * exm-gnome-shell-search-provider.h
+ *
+ * Copyright 2022-2026 Matthew Jakeman <mjakeman26@outlook.co.nz>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+
+#include "local/exm-manager.h"
+
+G_BEGIN_DECLS
+
+#define EXM_TYPE_GNOME_SHELL_SEARCH_PROVIDER (exm_gnome_shell_search_provider_get_type())
+
+G_DECLARE_FINAL_TYPE (ExmGnomeShellSearchProvider, exm_gnome_shell_search_provider, EXM, GNOME_SHELL_SEARCH_PROVIDER, GObject)
+
+ExmGnomeShellSearchProvider *exm_gnome_shell_search_provider_new (ExmManager *manager);
+
+gboolean exm_gnome_shell_search_provider_export   (ExmGnomeShellSearchProvider  *self,
+                                                    GDBusConnection              *connection,
+                                                    const gchar                  *object_path,
+                                                    GError                      **error);
+
+void     exm_gnome_shell_search_provider_unexport (ExmGnomeShellSearchProvider *self);
+
+G_END_DECLS

--- a/src/exm-window.c
+++ b/src/exm-window.c
@@ -96,6 +96,26 @@ exm_window_get_property (GObject    *object,
 }
 
 static void
+exm_window_set_property (GObject      *object,
+                         guint         prop_id,
+                         const GValue *value,
+                         GParamSpec   *pspec)
+{
+    ExmWindow *self = EXM_WINDOW (object);
+
+    switch (prop_id)
+    {
+    case PROP_MANAGER:
+        // Borrowed reference: the manager is owned by ExmApplication and
+        // outlives every window.
+        self->manager = g_value_get_object (value);
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
 extension_open_prefs (GtkWidget  *widget,
                       const char *action_name G_GNUC_UNUSED,
                       GVariant   *param)
@@ -388,6 +408,24 @@ search_online (GtkWidget  *widget,
     gtk_toggle_button_set_active (self->search_button, FALSE);
 }
 
+static void
+search_installed (GtkWidget  *widget,
+                  const char *action_name G_GNUC_UNUSED,
+                  GVariant   *param)
+{
+    ExmWindow *self;
+    const char *search_text;
+
+    self = EXM_WINDOW (widget);
+
+    adw_navigation_view_pop_to_page (self->navigation_view, self->main_view);
+    adw_view_stack_set_visible_child_name (self->view_stack, "installed");
+
+    search_text = g_variant_get_string (param, NULL);
+    gtk_editable_set_text (GTK_EDITABLE (gtk_search_bar_get_child (self->search_bar)), search_text);
+    gtk_toggle_button_set_active (self->search_button, TRUE);
+}
+
 
 static void
 on_error (ExmManager *manager G_GNUC_UNUSED,
@@ -478,18 +516,48 @@ screenshot_zoom (GtkWidget  *widget,
 }
 
 static void
+exm_window_constructed (GObject *object)
+{
+    ExmWindow *self = EXM_WINDOW (object);
+
+    G_OBJECT_CLASS (exm_window_parent_class)->constructed (object);
+
+    g_signal_connect (self->manager, "error-occurred", G_CALLBACK (on_error), self);
+    g_signal_connect_swapped (self->manager, "notify::is-supported",
+                              G_CALLBACK (sync_visible_page), self);
+    sync_visible_page (self);
+
+    g_object_set (self->installed_page, "manager", self->manager, NULL);
+    g_object_set (self->browse_page, "manager", self->manager, NULL);
+    g_object_set (self->detail_view, "manager", self->manager, NULL);
+
+    g_object_bind_property (self->manager,
+                            "shell-version",
+                            self->detail_view,
+                            "shell-version",
+                            G_BINDING_SYNC_CREATE);
+
+    g_signal_connect (self->manager,
+                      "updates-available",
+                      G_CALLBACK (on_updates_available),
+                      self);
+}
+
+static void
 exm_window_class_init (ExmWindowClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS (klass);
 
     object_class->get_property = exm_window_get_property;
+    object_class->set_property = exm_window_set_property;
+    object_class->constructed = exm_window_constructed;
 
     properties [PROP_MANAGER]
         = g_param_spec_object ("manager",
                                "Manager",
                                "Manager",
                                EXM_TYPE_MANAGER,
-                               G_PARAM_READABLE);
+                               G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY);
 
     g_object_class_install_properties (object_class, N_PROPS, properties);
 
@@ -537,6 +605,7 @@ exm_window_class_init (ExmWindowClass *klass)
     gtk_widget_class_install_action (widget_class, "win.show-error", "s", show_error);
     gtk_widget_class_install_action (widget_class, "win.show-error-dialog", "s", show_error_dialog);
     gtk_widget_class_install_action (widget_class, "win.search-online", NULL, search_online);
+    gtk_widget_class_install_action (widget_class, "win.search-installed", "s", search_installed);
     gtk_widget_class_install_action (widget_class, "win.discover-gnome", NULL, discover_gnome);
     gtk_widget_class_install_action (widget_class, "screenshot.zoom-in", NULL, screenshot_zoom);
     gtk_widget_class_install_action (widget_class, "screenshot.zoom-out", NULL, screenshot_zoom);
@@ -563,25 +632,4 @@ exm_window_init (ExmWindow *self)
 
     if (strstr (APP_ID, ".Devel") != NULL)
         gtk_widget_add_css_class (GTK_WIDGET (self), "devel");
-
-    self->manager = exm_manager_new ();
-    g_signal_connect (self->manager, "error-occurred", G_CALLBACK (on_error), self);
-    g_signal_connect_swapped (self->manager, "notify::is-supported",
-                              G_CALLBACK (sync_visible_page), self);
-    sync_visible_page (self);
-
-    g_object_set (self->installed_page, "manager", self->manager, NULL);
-    g_object_set (self->browse_page, "manager", self->manager, NULL);
-    g_object_set (self->detail_view, "manager", self->manager, NULL);
-
-    g_object_bind_property (self->manager,
-                            "shell-version",
-                            self->detail_view,
-                            "shell-version",
-                            G_BINDING_SYNC_CREATE);
-
-    g_signal_connect (self->manager,
-                      "updates-available",
-                      G_CALLBACK (on_updates_available),
-                      self);
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -2,6 +2,7 @@ exm_sources = [
   'main.c',
   'exm-window.c',
   'exm-application.c',
+  'exm-gnome-shell-search-provider.c',
 
   # Detail View
   'exm-detail-view.c',
@@ -52,6 +53,12 @@ if libbacktrace_dep.found()
 endif
 
 gnome = import('gnome')
+
+exm_sources += gnome.gdbus_codegen('exm-shell-search-provider-generated',
+  'org.gnome.Shell.SearchProvider2.xml',
+  interface_prefix: 'org.gnome.',
+  namespace: 'Exm',
+)
 
 subdir('local')
 subdir('web')

--- a/src/org.gnome.Shell.SearchProvider2.xml
+++ b/src/org.gnome.Shell.SearchProvider2.xml
@@ -1,0 +1,44 @@
+<!DOCTYPE node PUBLIC
+"-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+
+<!--
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General
+ Public License along with this library; if not, see <http://www.gnu.org/licenses/>.
+-->
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <interface name='org.gnome.Shell.SearchProvider2'>
+    <method name='GetInitialResultSet'>
+      <arg type='as' name='Terms' direction='in' />
+      <arg type='as' name='Results' direction='out' />
+    </method>
+    <method name = 'GetSubsearchResultSet'>
+      <arg type='as' name='PreviousResults' direction='in' />
+      <arg type='as' name='Terms' direction='in' />
+      <arg type='as' name='Results' direction='out' />
+    </method>
+    <method name = 'GetResultMetas'>
+      <arg type='as' name='Results' direction='in' />
+      <arg type='aa{sv}' name='Metas' direction='out' />
+    </method>
+    <method name = 'ActivateResult'>
+      <arg type='s' name='Result' direction='in' />
+      <arg type='as' name='Terms' direction='in' />
+      <arg type='u' name='Timestamp' direction='in' />
+    </method>
+    <method name = 'LaunchSearch'>
+      <arg type='as' name='Terms' direction='in' />
+      <arg type='u' name='Timestamp' direction='in' />
+    </method>
+  </interface>
+</node>


### PR DESCRIPTION
Installed extensions with preferences can now be found and opened straight from the Activities overview. Activating a result calls LaunchExtensionPrefs directly; picking the provider icon reuses the window and pre-fills the installed-extensions search with the same query.

Fix https://github.com/mjakeman/extension-manager/issues/313