### PR TITLE
Redesigned and implemented "Show in Files"

### DIFF
--- a/src/exm-detail-view.blp
+++ b/src/exm-detail-view.blp
@@ -197,18 +197,6 @@ template $ExmDetailView: Adw.NavigationPage {
                                 tooltip-text: _("Open extension preferences");
                                 action-name: "page.open-prefs";
                               }
-
-                              Gtk.Button files_btn {
-                                styles [
-                                  "circular",
-                                ]
-
-                                icon-name: "folder-open-symbolic";
-                                valign: center;
-                                // Translators: Button tooltip to show extension directory in Files
-                                tooltip-text: _("Show in Files");
-                                action-name: "page.show-files";
-                              }
                             }
 
                             Gtk.Switch ext_toggle {
@@ -362,6 +350,21 @@ template $ExmDetailView: Adw.NavigationPage {
 
                       [suffix]
                       Gtk.Label session_modes_label {}
+                    }
+
+                    Adw.ActionRow location_row {
+                      [prefix]
+                      Gtk.Image {
+                        icon-name: "system-file-manager-symbolic";
+                      }
+
+                      action-name: "detail.show-files";
+                      title: _("Location");
+
+                      [suffix]
+                      Gtk.Image location_row_folder_icon {
+                        icon-name: "folder-open-symbolic";
+                      }
                     }
                   }
 

--- a/src/exm-detail-view.blp
+++ b/src/exm-detail-view.blp
@@ -23,530 +23,537 @@ template $ExmDetailView: Adw.NavigationPage {
       };
     }
 
-    content: Adw.BreakpointBin {
-      width-request: 360;
-      height-request: 294;
+    content: Adw.ToastOverlay toast_overlay {
+      child: Adw.BreakpointBin {
+        width-request: 360;
+        height-request: 294;
 
-      Adw.Breakpoint {
-        condition ("max-width: 400sp")
+        Adw.Breakpoint {
+          condition ("max-width: 400sp")
 
-        setters {
-          header_suffix.orientation: vertical;
-          header_suffix.spacing: 12;
-          ext_install.halign: start;
+          setters {
+            header_suffix.orientation: vertical;
+            header_suffix.spacing: 12;
+            ext_install.halign: start;
+          }
+
+          apply => $breakpoint_apply_cb() swapped;
+          unapply => $breakpoint_unapply_cb() swapped;
         }
 
-        apply => $breakpoint_apply_cb() swapped;
-        unapply => $breakpoint_unapply_cb() swapped;
-      }
+        Gtk.Stack stack {
+          vexpand: true;
 
-      Gtk.Stack stack {
-        vexpand: true;
+          Gtk.StackPage {
+            name: "page_spinner";
 
-        Gtk.StackPage {
-          name: "page_spinner";
+            child: Adw.StatusPage loading_status {
+              paintable: spinner;
+              title: _("Loading Details");
+            };
+          }
 
-          child: Adw.StatusPage loading_status {
-            paintable: spinner;
-            title: _("Loading Details");
-          };
-        }
+          Gtk.StackPage {
+            name: "page_error";
 
-        Gtk.StackPage {
-          name: "page_error";
+            child: Adw.StatusPage error_status {
+              icon-name: "offline-symbolic";
+              title: _("Connection Error");
+              focusable: true;
+            };
+          }
 
-          child: Adw.StatusPage error_status {
-            icon-name: "offline-symbolic";
-            title: _("Connection Error");
-            focusable: true;
-          };
-        }
+          Gtk.StackPage {
+            name: "page_empty";
 
-        Gtk.StackPage {
-          name: "page_empty";
+            child: Adw.StatusPage {
+              icon-name: "dialog-question-symbolic";
+              title: _("An Error Occurred");
+              description: _("No extension details available");
+              focusable: true;
+            };
+          }
 
-          child: Adw.StatusPage {
-            icon-name: "dialog-question-symbolic";
-            title: _("An Error Occurred");
-            description: _("No extension details available");
-            focusable: true;
-          };
-        }
+          Gtk.StackPage {
+            name: "page_detail";
 
-        Gtk.StackPage {
-          name: "page_detail";
+            child: Gtk.Box {
+              orientation: vertical;
 
-          child: Gtk.Box {
-            orientation: vertical;
+              Adw.Banner error_banner {
+                // Translators: Banner title shown when the extension has a runtime error
+                title: _("This extension has an error");
+                button-label: _("_View Details");
+                action-name: "detail.show-error";
+              }
 
-            Adw.Banner error_banner {
-              // Translators: Banner title shown when the extension has a runtime error
-              title: _("This extension has an error");
-              button-label: _("_View Details");
-              action-name: "detail.show-error";
-            }
+              Gtk.ScrolledWindow scroll_area {
+                vexpand: true;
 
-            Gtk.ScrolledWindow scroll_area {
-              vexpand: true;
+                Adw.Clamp {
+                  maximum-size: 800;
 
-              Adw.Clamp {
-                maximum-size: 800;
+                  Gtk.Box {
+                    styles [
+                      "detail",
+                    ]
 
-                Gtk.Box {
-                  styles [
-                    "detail",
-                  ]
-
-                  orientation: vertical;
-                  spacing: 24;
-
-                  Gtk.Box header {
-                    orientation: horizontal;
+                    orientation: vertical;
                     spacing: 24;
 
-                    Gtk.Image ext_icon {
-                      focusable: true;
-                      halign: center;
-                      valign: center;
-                      pixel-size: 64;
-                    }
-
-                    Gtk.Box header_suffix {
+                    Gtk.Box header {
                       orientation: horizontal;
                       spacing: 24;
 
-                      Gtk.Box {
-                        orientation: vertical;
-                        hexpand: true;
+                      Gtk.Image ext_icon {
+                        focusable: true;
+                        halign: center;
                         valign: center;
+                        pixel-size: 64;
+                      }
 
-                        Gtk.Label ext_title {
-                          styles [
-                            "title-1",
-                          ]
+                      Gtk.Box header_suffix {
+                        orientation: horizontal;
+                        spacing: 24;
 
-                          ellipsize: end;
-                          label: bind template.data as <$ExmUnifiedData>.name;
-                          lines: 2;
-                          selectable: true;
-                          wrap: true;
-                          wrap-mode: word_char;
-                          xalign: 0;
+                        Gtk.Box {
+                          orientation: vertical;
+                          hexpand: true;
+                          valign: center;
 
-                          accessibility {
-                            description: _("Name");
+                          Gtk.Label ext_title {
+                            styles [
+                              "title-1",
+                            ]
+
+                            ellipsize: end;
+                            label: bind template.data as <$ExmUnifiedData>.name;
+                            lines: 2;
+                            selectable: true;
+                            wrap: true;
+                            wrap-mode: word_char;
+                            xalign: 0;
+
+                            accessibility {
+                              description: _("Name");
+                            }
+                          }
+
+                          Gtk.Label ext_author {
+                            styles [
+                              "dimmed",
+                            ]
+
+                            label: bind template.data as <$ExmUnifiedData>.creator;
+                            xalign: 0;
+                            ellipsize: end;
+                            selectable: true;
+
+                            accessibility {
+                              description: _("Author");
+                            }
                           }
                         }
 
-                        Gtk.Label ext_author {
-                          styles [
-                            "dimmed",
-                          ]
+                        Gtk.Stack tools_stack {
+                          Gtk.StackPage {
+                            name: "uninstalled-tools-page";
 
-                          label: bind template.data as <$ExmUnifiedData>.creator;
-                          xalign: 0;
-                          ellipsize: end;
-                          selectable: true;
+                            child: $ExmInstallButton ext_install {
+                              can-shrink: true;
+                              clicked => $install_remote();
+                            };
+                          }
 
-                          accessibility {
-                            description: _("Author");
+                          Gtk.StackPage {
+                            name: "installed-tools-page";
+
+                            child: Gtk.Box {
+                              spacing: 16;
+
+                              Gtk.Box {
+                                spacing: 6;
+
+                                Gtk.Button remove_btn {
+                                  styles [
+                                    "circular",
+                                    "destructive-action",
+                                  ]
+
+                                  icon-name: "user-trash-symbolic";
+                                  valign: center;
+                                  // Translators: Button tooltip to remove an installed extension
+                                  tooltip-text: _("Remove Extension");
+                                  action-name: "page.remove";
+                                }
+
+                                Gtk.Button prefs_btn {
+                                  styles [
+                                    "circular",
+                                  ]
+
+                                  icon-name: "settings-symbolic";
+                                  valign: center;
+                                  // Translators: Button tooltip to open extension preferences
+                                  tooltip-text: _("Open extension preferences");
+                                  action-name: "page.open-prefs";
+                                }
+                              }
+
+                              Gtk.Switch ext_toggle {
+                                valign: center;
+                                // Translators: Switch tooltip to enable or disable the extension
+                                tooltip-text: _("Toggle Extension");
+                                state-set => $on_toggle_changed();
+                              }
+                            };
                           }
                         }
                       }
-
-                      Gtk.Stack tools_stack {
-                        Gtk.StackPage {
-                          name: "uninstalled-tools-page";
-
-                          child: $ExmInstallButton ext_install {
-                            can-shrink: true;
-                            clicked => $install_remote();
-                          };
-                        }
-
-                        Gtk.StackPage {
-                          name: "installed-tools-page";
-
-                          child: Gtk.Box {
-                            spacing: 16;
-
-                            Gtk.Box {
-                              spacing: 6;
-
-                              Gtk.Button remove_btn {
-                                styles [
-                                  "circular",
-                                  "destructive-action",
-                                ]
-
-                                icon-name: "user-trash-symbolic";
-                                valign: center;
-                                // Translators: Button tooltip to remove an installed extension
-                                tooltip-text: _("Remove Extension");
-                                action-name: "page.remove";
-                              }
-
-                              Gtk.Button prefs_btn {
-                                styles [
-                                  "circular",
-                                ]
-
-                                icon-name: "settings-symbolic";
-                                valign: center;
-                                // Translators: Button tooltip to open extension preferences
-                                tooltip-text: _("Open extension preferences");
-                                action-name: "page.open-prefs";
-                              }
-                            }
-
-                            Gtk.Switch ext_toggle {
-                              valign: center;
-                              // Translators: Switch tooltip to enable or disable the extension
-                              tooltip-text: _("Toggle Extension");
-                              state-set => $on_toggle_changed();
-                            }
-                          };
-                        }
-                      }
-                    }
-                  }
-
-                  Gtk.Overlay ext_screenshot_container {
-                    [overlay]
-                    Gtk.Button ext_screenshot_popout_button {
-                      styles [
-                        "osd",
-                        "circular",
-                      ]
-
-                      icon-name: "pip-out-symbolic";
-                      halign: end;
-                      valign: end;
-                      margin-top: 8;
-                      margin-bottom: 8;
-                      margin-start: 8;
-                      margin-end: 8;
-                      tooltip-text: _("Enlarge Image");
-                      action-name: "win.show-screenshot";
                     }
 
-                    $ExmScreenshot ext_screenshot {
-                      focusable: true;
-                    }
-                  }
-
-                  Gtk.Box {
-                    orientation: vertical;
-
-                    Gtk.Label description {
-                      styles [
-                        "title-4",
-                        "detail-heading",
-                      ]
-
-                      label: _("Description");
-                      xalign: 0;
-                    }
-
-                    Gtk.Label ext_description {
-                      styles [
-                        "multiline",
-                      ]
-
-                      label: bind template.data as <$ExmUnifiedData>.description;
-                      xalign: 0;
-                      wrap: true;
-                      wrap-mode: word_char;
-                      selectable: true;
-
-                      accessibility {
-                        labelled-by: description;
-                      }
-                    }
-                  }
-
-                  Adw.PreferencesGroup {
-                    Adw.ActionRow downloads_row {
-                      [prefix]
-                      Gtk.Image {
-                        icon-name: "folder-download-symbolic";
-                      }
-
-                      title: C_("Number of downloads", "Downloads");
-
-                      [suffix]
-                      Gtk.Label downloads_label {
+                    Gtk.Overlay ext_screenshot_container {
+                      [overlay]
+                      Gtk.Button ext_screenshot_popout_button {
                         styles [
-                          "numeric",
+                          "osd",
+                          "circular",
                         ]
 
-                        label: bind $format_downloads(template.data as <$ExmUnifiedData>.downloads) as <string>;
+                        icon-name: "pip-out-symbolic";
+                        halign: end;
+                        valign: end;
+                        margin-top: 8;
+                        margin-bottom: 8;
+                        margin-start: 8;
+                        margin-end: 8;
+                        tooltip-text: _("Enlarge Image");
+                        action-name: "win.show-screenshot";
+                      }
+
+                      $ExmScreenshot ext_screenshot {
+                        focusable: true;
                       }
                     }
 
-                    Adw.ActionRow version_row {
-                      [prefix]
-                      Gtk.Image {
-                        icon-name: "system-software-install-symbolic";
+                    Gtk.Box {
+                      orientation: vertical;
+
+                      Gtk.Label description {
+                        styles [
+                          "title-4",
+                          "detail-heading",
+                        ]
+
+                        label: _("Description");
+                        xalign: 0;
                       }
 
-                      action-name: "detail.show-versions";
-                      activatable: true;
-                      title: _("Version");
+                      Gtk.Label ext_description {
+                        styles [
+                          "multiline",
+                        ]
 
-                      [suffix]
-                      Gtk.Box {
-                        spacing: 6;
+                        label: bind template.data as <$ExmUnifiedData>.description;
+                        xalign: 0;
+                        wrap: true;
+                        wrap-mode: word_char;
+                        selectable: true;
 
-                        Gtk.Image update_icon {
-                          styles [
-                            "update",
-                          ]
+                        accessibility {
+                          labelled-by: description;
+                        }
+                      }
+                    }
 
-                          icon-name: "software-update-available-symbolic";
-                          valign: center;
-                          margin-start: 9;
-                          margin-end: 9;
-                          visible: false;
-                          // Translators: Icon's tooltip when an extension update is available
-                          tooltip-text: _("A newer version of this extension is available");
+                    Adw.PreferencesGroup {
+                      Adw.ActionRow downloads_row {
+                        [prefix]
+                        Gtk.Image {
+                          icon-name: "folder-download-symbolic";
                         }
 
-                        Gtk.Image out_of_date_icon {
-                          styles [
-                            "error",
-                          ]
+                        title: C_("Number of downloads", "Downloads");
 
-                          icon-name: "clock-alt-symbolic";
-                          valign: center;
-                          margin-start: 9;
-                          margin-end: 9;
-                          visible: false;
-                          // Translators: Icon's tooltip when an extension is incompatible
-                          tooltip-text: _("This extension is incompatible with your current version of GNOME");
-                        }
-
-                        Gtk.Label version_label {
-                          // TODO: Drop when version-label is available
+                        [suffix]
+                        Gtk.Label downloads_label {
                           styles [
                             "numeric",
                           ]
-                        }
 
-                        Gtk.Image version_row_go_next {
-                          icon-name: "go-next-symbolic";
+                          label: bind $format_downloads(template.data as <$ExmUnifiedData>.downloads) as <string>;
                         }
                       }
-                    }
 
-                    Adw.ActionRow session_modes_row {
-                      [prefix]
-                      Gtk.Image {
-                        icon-name: "session-modes-symbolic";
-                      }
+                      Adw.ActionRow version_row {
+                        [prefix]
+                        Gtk.Image {
+                          icon-name: "system-software-install-symbolic";
+                        }
 
-                      title: _("Session Modes");
-                      visible: false;
+                        action-name: "detail.show-versions";
+                        activatable: true;
+                        title: _("Version");
 
-                      [suffix]
-                      Gtk.Label session_modes_label {}
-                    }
-
-                    Adw.ActionRow location_row {
-                      [prefix]
-                      Gtk.Image {
-                        icon-name: "system-file-manager-symbolic";
-                      }
-
-                      action-name: "detail.show-files";
-                      title: _("Location");
-
-                      [suffix]
-                      Gtk.Image location_row_folder_icon {
-                        icon-name: "folder-open-symbolic";
-                      }
-                    }
-                  }
-
-                  Adw.PreferencesGroup links_group {
-                    title: _("Links");
-
-                    Adw.ActionRow link_homepage {
-                      [prefix]
-                      Gtk.Image {
-                        icon-name: "go-home-symbolic";
-                      }
-
-                      action-name: "detail.open-homepage";
-                      activatable: true;
-                      title: _("Homepage");
-                      subtitle: bind template.data as <$ExmUnifiedData>.homepage;
-                      visible: bind $has_homepage(template.data as <$ExmUnifiedData>.homepage) as <bool>;
-
-                      [suffix]
-                      Gtk.Image {
-                        icon-name: "external-link-symbolic";
-                      }
-                    }
-
-                    Adw.ActionRow link_donation {
-                      [prefix]
-                      Gtk.Image {
-                        icon-name: "donation-symbolic";
-                      }
-
-                      title: _("Donate");
-                      activatable: true;
-
-                      [suffix]
-                      Gtk.Image {
-                        icon-name: "external-link-symbolic";
-                      }
-                    }
-
-                    Adw.ExpanderRow links_donations {
-                      [prefix]
-                      Gtk.Image {
-                        icon-name: "donation-symbolic";
-                      }
-
-                      title: _("Donate");
-                    }
-
-                    Adw.ActionRow link_extensions {
-                      [prefix]
-                      Gtk.Image {
-                        icon-name: "web-browser-symbolic";
-                      }
-
-                      action-name: "detail.open-extensions";
-                      activatable: true;
-                      title: _("View on Extensions");
-
-                      [suffix]
-                      Gtk.Image {
-                        icon-name: "external-link-symbolic";
-                      }
-                    }
-                  }
-
-                  Gtk.Box comments_section {
-                    orientation: vertical;
-
-                    Gtk.Label {
-                      styles [
-                        "title-4",
-                        "detail-heading",
-                      ]
-
-                      label: _("Reviews and Comments");
-                      selectable: true;
-                      xalign: 0;
-                    }
-
-                    // TODO: Abstract into common class
-                    Gtk.Stack comment_stack {
-                      vexpand: true;
-
-                      Gtk.StackPage {
-                        name: "page_spinner";
-
-                        child: Gtk.Image {
-                          icon-name: "content-loading-symbolic";
-                          icon-size: large;
-                          valign: center;
-                        };
-                      }
-
-                      Gtk.StackPage {
-                        name: "page_disabled";
-
-                        child: Gtk.Label {
-                          label: _("Reviews and comments are disabled for this extension");
-                          selectable: true;
-                          valign: start;
-                          wrap: true;
-                          xalign: 0;
-                        };
-                      }
-
-                      Gtk.StackPage {
-                        name: "page_error";
-
-                        child: Gtk.Box {
-                          orientation: vertical;
+                        [suffix]
+                        Gtk.Box {
                           spacing: 6;
 
-                          Gtk.Label {
+                          Gtk.Image update_icon {
                             styles [
-                              "heading",
+                              "update",
                             ]
 
-                            label: _("Connection Error");
-                            selectable: true;
-                            valign: start;
-                            xalign: 0;
+                            icon-name: "software-update-available-symbolic";
+                            valign: center;
+                            margin-start: 9;
+                            margin-end: 9;
+                            visible: false;
+                            // Translators: Icon's tooltip when an extension update is available
+                            tooltip-text: _("A newer version of this extension is available");
                           }
 
-                          Gtk.Label error_label {
+                          Gtk.Image out_of_date_icon {
                             styles [
-                              "body",
+                              "error",
                             ]
 
-                            selectable: true;
-                            use-markup: true;
-                            valign: start;
-                            xalign: 0;
+                            icon-name: "clock-alt-symbolic";
+                            valign: center;
+                            margin-start: 9;
+                            margin-end: 9;
+                            visible: false;
+                            // Translators: Icon's tooltip when an extension is incompatible
+                            tooltip-text: _("This extension is incompatible with your current version of GNOME");
                           }
-                        };
+
+                          Gtk.Label version_label {
+                            // TODO: Drop when version-label is available
+                            styles [
+                              "numeric",
+                            ]
+                          }
+
+                          Gtk.Image version_row_go_next {
+                            icon-name: "go-next-symbolic";
+                          }
+                        }
                       }
 
-                      Gtk.StackPage {
-                        name: "page_empty";
+                      Adw.ActionRow session_modes_row {
+                        [prefix]
+                        Gtk.Image {
+                          icon-name: "session-modes-symbolic";
+                        }
 
-                        child: Gtk.Label {
-                          label: _("There are no reviews or comments");
-                          selectable: true;
-                          valign: start;
-                          wrap: true;
-                          xalign: 0;
-                        };
+                        title: _("Session Modes");
+                        visible: false;
+
+                        [suffix]
+                        Gtk.Label session_modes_label {}
                       }
 
-                      Gtk.StackPage {
-                        name: "page_comments";
+                      Adw.ActionRow location_row {
+                        [prefix]
+                        Gtk.Image {
+                          icon-name: "system-file-manager-symbolic";
+                        }
 
-                        child: Gtk.Box {
-                          orientation: vertical;
-                          spacing: 12;
+                        action-name: "detail.show-files-or-copy-path";
+                        activatable: true;
+                        title: _("Location");
 
-                          Adw.WrapBox comment_box {
+                        [suffix]
+                        Gtk.Image location_row_folder_icon {
+                          icon-name: "folder-open-symbolic";
+                        }
+
+                        Gtk.Image location_row_copy_icon {
+                          icon-name: "edit-copy-symbolic";
+                        }
+                      }
+                    }
+
+                    Adw.PreferencesGroup links_group {
+                      title: _("Links");
+
+                      Adw.ActionRow link_homepage {
+                        [prefix]
+                        Gtk.Image {
+                          icon-name: "go-home-symbolic";
+                        }
+
+                        action-name: "detail.open-homepage";
+                        activatable: true;
+                        title: _("Homepage");
+                        subtitle: bind template.data as <$ExmUnifiedData>.homepage;
+                        visible: bind $has_homepage(template.data as <$ExmUnifiedData>.homepage) as <bool>;
+
+                        [suffix]
+                        Gtk.Image {
+                          icon-name: "external-link-symbolic";
+                        }
+                      }
+
+                      Adw.ActionRow link_donation {
+                        [prefix]
+                        Gtk.Image {
+                          icon-name: "donation-symbolic";
+                        }
+
+                        title: _("Donate");
+                        activatable: true;
+
+                        [suffix]
+                        Gtk.Image {
+                          icon-name: "external-link-symbolic";
+                        }
+                      }
+
+                      Adw.ExpanderRow links_donations {
+                        [prefix]
+                        Gtk.Image {
+                          icon-name: "donation-symbolic";
+                        }
+
+                        title: _("Donate");
+                      }
+
+                      Adw.ActionRow link_extensions {
+                        [prefix]
+                        Gtk.Image {
+                          icon-name: "web-browser-symbolic";
+                        }
+
+                        action-name: "detail.open-extensions";
+                        activatable: true;
+                        title: _("View on Extensions");
+
+                        [suffix]
+                        Gtk.Image {
+                          icon-name: "external-link-symbolic";
+                        }
+                      }
+                    }
+
+                    Gtk.Box comments_section {
+                      orientation: vertical;
+
+                      Gtk.Label {
+                        styles [
+                          "title-4",
+                          "detail-heading",
+                        ]
+
+                        label: _("Reviews and Comments");
+                        selectable: true;
+                        xalign: 0;
+                      }
+
+                      // TODO: Abstract into common class
+                      Gtk.Stack comment_stack {
+                        vexpand: true;
+
+                        Gtk.StackPage {
+                          name: "page_spinner";
+
+                          child: Gtk.Image {
+                            icon-name: "content-loading-symbolic";
+                            icon-size: large;
+                            valign: center;
+                          };
+                        }
+
+                        Gtk.StackPage {
+                          name: "page_disabled";
+
+                          child: Gtk.Label {
+                            label: _("Reviews and comments are disabled for this extension");
+                            selectable: true;
+                            valign: start;
+                            wrap: true;
+                            xalign: 0;
+                          };
+                        }
+
+                        Gtk.StackPage {
+                          name: "page_error";
+
+                          child: Gtk.Box {
                             orientation: vertical;
-                            child-spacing: 12;
-                            line-homogeneous: true;
-                            line-spacing: 12;
-                          }
+                            spacing: 6;
 
-                          Gtk.Button show_more_btn {
-                            styles [
-                              "pill",
-                            ]
+                            Gtk.Label {
+                              styles [
+                                "heading",
+                              ]
 
-                            can-shrink: true;
-                            halign: center;
-                            label: _("_Show All");
-                            use-underline: true;
-                          }
-                        };
+                              label: _("Connection Error");
+                              selectable: true;
+                              valign: start;
+                              xalign: 0;
+                            }
+
+                            Gtk.Label error_label {
+                              styles [
+                                "body",
+                              ]
+
+                              selectable: true;
+                              use-markup: true;
+                              valign: start;
+                              xalign: 0;
+                            }
+                          };
+                        }
+
+                        Gtk.StackPage {
+                          name: "page_empty";
+
+                          child: Gtk.Label {
+                            label: _("There are no reviews or comments");
+                            selectable: true;
+                            valign: start;
+                            wrap: true;
+                            xalign: 0;
+                          };
+                        }
+
+                        Gtk.StackPage {
+                          name: "page_comments";
+
+                          child: Gtk.Box {
+                            orientation: vertical;
+                            spacing: 12;
+
+                            Adw.WrapBox comment_box {
+                              orientation: vertical;
+                              child-spacing: 12;
+                              line-homogeneous: true;
+                              line-spacing: 12;
+                            }
+
+                            Gtk.Button show_more_btn {
+                              styles [
+                                "pill",
+                              ]
+
+                              can-shrink: true;
+                              halign: center;
+                              label: _("_Show All");
+                              use-underline: true;
+                            }
+                          };
+                        }
                       }
                     }
                   }
                 }
               }
-            }
-          };
+            };
+          }
         }
-      }
+      };
     };
   }
 }

--- a/src/exm-detail-view.c
+++ b/src/exm-detail-view.c
@@ -63,6 +63,7 @@ struct _ExmDetailView
 
     AdwHeaderBar *header_bar;
     GtkRevealer *title_revealer;
+    AdwToastOverlay *toast_overlay;
     GtkStack *stack;
     GtkLabel *error_label;
     AdwStatusPage *error_status;
@@ -88,6 +89,7 @@ struct _ExmDetailView
     GtkLabel *session_modes_label;
     AdwActionRow *location_row;
     GtkImage *location_row_folder_icon;
+    GtkImage *location_row_copy_icon;
     AdwBanner *error_banner;
     gchar *error_text;
     AdwPreferencesGroup *links_group;
@@ -1027,29 +1029,47 @@ show_error (GtkWidget  *widget,
 }
 
 static void
-show_file (ExmDetailView *self,
+show_files_or_copy_path (ExmDetailView *self,
            const char    *action_name G_GNUC_UNUSED,
            GVariant      *param G_GNUC_UNUSED)
 {
-    GtkWidget *toplevel;
     ExmExtension *extension;
+    gboolean is_user;
     g_autofree gchar *path = NULL;
-    g_autoptr (GFile) file = NULL;
-    g_autoptr (GtkFileLauncher) launcher = NULL;
-
-    toplevel = GTK_WIDGET (gtk_widget_get_root (GTK_WIDGET (self)));
 
     extension = exm_manager_get_by_uuid (self->manager, self->uuid);
 
     g_object_get (extension,
+                  "is_user", &is_user,
                   "path", &path,
                   NULL);
 
-    file = g_file_new_for_path (path);
+    if (is_user) 
+    {
+        GtkWidget *toplevel;
+        g_autoptr (GFile) file = NULL;
+        g_autoptr (GtkFileLauncher) launcher = NULL;
 
-    launcher = gtk_file_launcher_new (file);
+        toplevel = GTK_WIDGET (gtk_widget_get_root (GTK_WIDGET (self)));
 
-    gtk_file_launcher_launch (launcher, GTK_WINDOW (toplevel), NULL, NULL, NULL);
+        file = g_file_new_for_path (path);
+
+        launcher = gtk_file_launcher_new (file);
+
+        gtk_file_launcher_launch (launcher, GTK_WINDOW (toplevel), NULL, NULL, NULL);
+    }
+    else
+    {
+        GdkDisplay *display;
+        GdkClipboard *clipboard;
+
+        display = gdk_display_get_default ();
+        clipboard = gdk_display_get_clipboard (display);
+
+        gdk_clipboard_set_text (clipboard, path);
+
+        adw_toast_overlay_add_toast (self->toast_overlay, adw_toast_new (_("Copied")));
+    }
 }
 
 static void
@@ -1181,7 +1201,7 @@ update_tools_stack (ExmDetailView *self)
             adw_action_row_set_subtitle(self->location_row, path);
             gtk_widget_set_visible (GTK_WIDGET (self->location_row), TRUE);
             gtk_widget_set_visible (GTK_WIDGET (self->location_row_folder_icon), is_user);
-            gtk_list_box_row_set_activatable (GTK_LIST_BOX_ROW (self->location_row), is_user);
+            gtk_widget_set_visible (GTK_WIDGET (self->location_row_copy_icon), !is_user);
 
             {
                 gboolean has_error = (error_msg != NULL) && (error_msg[0] != '\0');
@@ -1304,6 +1324,7 @@ exm_detail_view_class_init (ExmDetailViewClass *klass)
 
     gtk_widget_class_set_template_from_resource (widget_class, g_strdup_printf ("%s/exm-detail-view.ui", RESOURCE_PATH));
 
+    gtk_widget_class_bind_template_child (widget_class, ExmDetailView, toast_overlay);
     gtk_widget_class_bind_template_child (widget_class, ExmDetailView, header_bar);
     gtk_widget_class_bind_template_child (widget_class, ExmDetailView, title_revealer);
     gtk_widget_class_bind_template_child (widget_class, ExmDetailView, stack);
@@ -1331,6 +1352,7 @@ exm_detail_view_class_init (ExmDetailViewClass *klass)
     gtk_widget_class_bind_template_child (widget_class, ExmDetailView, session_modes_label);
     gtk_widget_class_bind_template_child (widget_class, ExmDetailView, location_row);
     gtk_widget_class_bind_template_child (widget_class, ExmDetailView, location_row_folder_icon);
+    gtk_widget_class_bind_template_child (widget_class, ExmDetailView, location_row_copy_icon);
     gtk_widget_class_bind_template_child (widget_class, ExmDetailView, error_banner);
     gtk_widget_class_bind_template_child (widget_class, ExmDetailView, links_group);
     gtk_widget_class_bind_template_child (widget_class, ExmDetailView, comments_section);
@@ -1352,7 +1374,7 @@ exm_detail_view_class_init (ExmDetailViewClass *klass)
 
     gtk_widget_class_install_action (widget_class, "detail.show-versions", NULL, show_versions);
     gtk_widget_class_install_action (widget_class, "detail.show-error", NULL, show_error);
-    gtk_widget_class_install_action (widget_class, "detail.show-files", NULL, (GtkWidgetActionActivateFunc) show_file);
+    gtk_widget_class_install_action (widget_class, "detail.show-files-or-copy-path", NULL, (GtkWidgetActionActivateFunc) show_files_or_copy_path);
     gtk_widget_class_install_action (widget_class, "detail.open-extensions", NULL, (GtkWidgetActionActivateFunc) open_link);
     gtk_widget_class_install_action (widget_class, "detail.open-homepage", NULL, (GtkWidgetActionActivateFunc) open_link);
     gtk_widget_class_install_action (widget_class, "detail.open-donations", "i", (GtkWidgetActionActivateFunc) open_link);

--- a/src/exm-detail-view.c
+++ b/src/exm-detail-view.c
@@ -70,7 +70,6 @@ struct _ExmDetailView
     GtkButton *ext_install;
     GtkButton *remove_btn;
     GtkButton *prefs_btn;
-    GtkButton *files_btn;
     GtkSwitch *ext_toggle;
     GtkLabel *ext_description;
     GtkImage *ext_icon;
@@ -1173,8 +1172,6 @@ update_tools_stack (ExmDetailView *self)
             gtk_widget_set_visible (GTK_WIDGET (self->prefs_btn), has_prefs);
 
             gtk_widget_set_visible (GTK_WIDGET (self->remove_btn), is_user);
-
-            gtk_widget_set_visible (GTK_WIDGET (self->files_btn), is_user);
 
             gtk_widget_set_visible (GTK_WIDGET (self->update_icon), has_update);
 

--- a/src/exm-detail-view.c
+++ b/src/exm-detail-view.c
@@ -87,6 +87,8 @@ struct _ExmDetailView
     GtkLabel *version_label;
     AdwActionRow *session_modes_row;
     GtkLabel *session_modes_label;
+    AdwActionRow *location_row;
+    GtkImage *location_row_folder_icon;
     AdwBanner *error_banner;
     gchar *error_text;
     AdwPreferencesGroup *links_group;
@@ -1026,6 +1028,32 @@ show_error (GtkWidget  *widget,
 }
 
 static void
+show_file (ExmDetailView *self,
+           const char    *action_name G_GNUC_UNUSED,
+           GVariant      *param G_GNUC_UNUSED)
+{
+    GtkWidget *toplevel;
+    ExmExtension *extension;
+    g_autofree gchar *path = NULL;
+    g_autoptr (GFile) file = NULL;
+    g_autoptr (GtkFileLauncher) launcher = NULL;
+
+    toplevel = GTK_WIDGET (gtk_widget_get_root (GTK_WIDGET (self)));
+
+    extension = exm_manager_get_by_uuid (self->manager, self->uuid);
+
+    g_object_get (extension,
+                  "path", &path,
+                  NULL);
+
+    file = g_file_new_for_path (path);
+
+    launcher = gtk_file_launcher_new (file);
+
+    gtk_file_launcher_launch (launcher, GTK_WINDOW (toplevel), NULL, NULL, NULL);
+}
+
+static void
 open_link (ExmDetailView *self,
            const char    *action_name,
            GVariant      *param)
@@ -1090,19 +1118,6 @@ page_remove (GSimpleAction *action G_GNUC_UNUSED,
         exm_manager_remove_extension (self->manager, extension);
 }
 
-static void
-page_show_files (GSimpleAction *action G_GNUC_UNUSED,
-                 GVariant      *param G_GNUC_UNUSED,
-                 ExmDetailView *self)
-{
-    if (!self->uuid || !self->manager)
-        return;
-
-    ExmExtension *extension = exm_manager_get_by_uuid (self->manager, self->uuid);
-    if (extension)
-        exm_manager_show_files (self->manager, extension);
-}
-
 static gboolean
 on_toggle_changed (GtkSwitch     *toggle,
                    gboolean       state,
@@ -1144,12 +1159,14 @@ update_tools_stack (ExmDetailView *self)
         {
             gboolean has_prefs, is_user, has_update;
             ExmExtensionState state;
+            gchar *path = NULL;
             char *error_msg = NULL;
             g_object_get (extension,
                           "has-prefs",  &has_prefs,
                           "is-user",    &is_user,
                           "state",      &state,
                           "has-update", &has_update,
+                          "path",       &path,
                           "error",      &error_msg,
                           NULL);
 
@@ -1164,6 +1181,11 @@ update_tools_stack (ExmDetailView *self)
             gtk_widget_set_visible (GTK_WIDGET (self->out_of_date_icon),
                                     state == EXM_EXTENSION_STATE_OUT_OF_DATE);
 
+            adw_action_row_set_subtitle(self->location_row, path);
+            gtk_widget_set_visible (GTK_WIDGET (self->location_row), TRUE);
+            gtk_widget_set_visible (GTK_WIDGET (self->location_row_folder_icon), is_user);
+            gtk_list_box_row_set_activatable (GTK_LIST_BOX_ROW (self->location_row), is_user);
+
             {
                 gboolean has_error = (error_msg != NULL) && (error_msg[0] != '\0');
 
@@ -1171,6 +1193,7 @@ update_tools_stack (ExmDetailView *self)
                 self->error_text = has_error ? g_strdup (error_msg) : NULL;
                 adw_banner_set_revealed (self->error_banner, has_error);
             }
+            g_free (path);
             g_free (error_msg);
 
             exm_extension_bind_toggle (extension, self->ext_toggle);
@@ -1181,6 +1204,8 @@ update_tools_stack (ExmDetailView *self)
         gtk_widget_set_visible (GTK_WIDGET (self->update_icon), FALSE);
         gtk_widget_set_visible (GTK_WIDGET (self->out_of_date_icon), FALSE);
         adw_banner_set_revealed (self->error_banner, FALSE);
+
+        gtk_widget_set_visible (GTK_WIDGET (self->location_row), FALSE);
     }
 }
 
@@ -1295,7 +1320,6 @@ exm_detail_view_class_init (ExmDetailViewClass *klass)
     gtk_widget_class_bind_template_child (widget_class, ExmDetailView, ext_install);
     gtk_widget_class_bind_template_child (widget_class, ExmDetailView, remove_btn);
     gtk_widget_class_bind_template_child (widget_class, ExmDetailView, prefs_btn);
-    gtk_widget_class_bind_template_child (widget_class, ExmDetailView, files_btn);
     gtk_widget_class_bind_template_child (widget_class, ExmDetailView, ext_toggle);
     gtk_widget_class_bind_template_child (widget_class, ExmDetailView, ext_screenshot);
     gtk_widget_class_bind_template_child (widget_class, ExmDetailView, ext_screenshot_container);
@@ -1308,6 +1332,8 @@ exm_detail_view_class_init (ExmDetailViewClass *klass)
     gtk_widget_class_bind_template_child (widget_class, ExmDetailView, version_label);
     gtk_widget_class_bind_template_child (widget_class, ExmDetailView, session_modes_row);
     gtk_widget_class_bind_template_child (widget_class, ExmDetailView, session_modes_label);
+    gtk_widget_class_bind_template_child (widget_class, ExmDetailView, location_row);
+    gtk_widget_class_bind_template_child (widget_class, ExmDetailView, location_row_folder_icon);
     gtk_widget_class_bind_template_child (widget_class, ExmDetailView, error_banner);
     gtk_widget_class_bind_template_child (widget_class, ExmDetailView, links_group);
     gtk_widget_class_bind_template_child (widget_class, ExmDetailView, comments_section);
@@ -1329,6 +1355,7 @@ exm_detail_view_class_init (ExmDetailViewClass *klass)
 
     gtk_widget_class_install_action (widget_class, "detail.show-versions", NULL, show_versions);
     gtk_widget_class_install_action (widget_class, "detail.show-error", NULL, show_error);
+    gtk_widget_class_install_action (widget_class, "detail.show-files", NULL, (GtkWidgetActionActivateFunc) show_file);
     gtk_widget_class_install_action (widget_class, "detail.open-extensions", NULL, (GtkWidgetActionActivateFunc) open_link);
     gtk_widget_class_install_action (widget_class, "detail.open-homepage", NULL, (GtkWidgetActionActivateFunc) open_link);
     gtk_widget_class_install_action (widget_class, "detail.open-donations", "i", (GtkWidgetActionActivateFunc) open_link);
@@ -1342,7 +1369,6 @@ exm_detail_view_init (ExmDetailView *self)
 
     GSimpleAction *open_prefs_action;
     GSimpleAction *remove_action;
-    GSimpleAction *show_files_action;
 
     g_type_ensure (EXM_TYPE_INSTALL_BUTTON);
     g_type_ensure (EXM_TYPE_SCREENSHOT);
@@ -1368,12 +1394,8 @@ exm_detail_view_init (ExmDetailView *self)
     remove_action = g_simple_action_new ("remove", NULL);
     g_signal_connect (remove_action, "activate", G_CALLBACK (page_remove), self);
 
-    show_files_action = g_simple_action_new ("show-files", NULL);
-    g_signal_connect (show_files_action, "activate", G_CALLBACK (page_show_files), self);
-
     g_action_map_add_action (G_ACTION_MAP (self->action_group), G_ACTION (open_prefs_action));
     g_action_map_add_action (G_ACTION_MAP (self->action_group), G_ACTION (remove_action));
-    g_action_map_add_action (G_ACTION_MAP (self->action_group), G_ACTION (show_files_action));
 
     gtk_widget_insert_action_group (GTK_WIDGET (self), "page", G_ACTION_GROUP (self->action_group));
 }

--- a/src/local/exm-manager.c
+++ b/src/local/exm-manager.c
@@ -310,49 +310,6 @@ exm_manager_open_prefs (ExmManager   *self,
                                                   create_callback_data (self, extension));
 }
 
-static void
-show_files_done (GObject         *source_object G_GNUC_UNUSED,
-                 GAsyncResult    *result,
-                 ExmCallbackData *data)
-{
-    GError *error = NULL;
-    gboolean success = g_app_info_launch_default_for_uri_finish (result, &error);
-
-    if (!success)
-    {
-        if (error)
-        {
-            g_warning ("Could not Show extension in Files: %s", error->message);
-            g_error_free (error);
-        }
-        else
-        {
-            g_warning ("Could not Show extension in Files: unknown failure");
-        }
-    }
-
-    free_callback_data (data);
-}
-
-void
-exm_manager_show_files (ExmManager   *self,
-                        ExmExtension *extension)
-{
-    gchar *path;
-    g_object_get (extension, "path", &path, NULL);
-
-    gchar *uri = g_filename_to_uri(path, NULL, NULL);
-
-    g_app_info_launch_default_for_uri_async (uri,
-                                             NULL,
-                                             NULL,
-                                             (GAsyncReadyCallback) show_files_done,
-                                             create_callback_data (self, extension));
-
-    g_free (uri);
-    g_free (path);
-}
-
 static gpointer
 list_model_get_by_uuid (GListModel  *model,
                         const gchar *uuid)

--- a/src/local/exm-manager.h
+++ b/src/local/exm-manager.h
@@ -41,8 +41,6 @@ void          exm_manager_remove_extension  (ExmManager           *self,
                                              ExmExtension         *extension);
 void          exm_manager_open_prefs        (ExmManager           *self,
                                              ExmExtension         *extension);
-void          exm_manager_show_files        (ExmManager           *self,
-                                             ExmExtension         *extension);
 void          exm_manager_check_for_updates (ExmManager           *self);
 gboolean      exm_manager_is_installed_uuid (ExmManager           *self,
                                              const gchar          *uuid);


### PR DESCRIPTION
Based on the previous brief discussion(https://github.com/mjakeman/extension-manager/pull/969#pullrequestreview-4831550531), the extension path will be displayed at the location shown in the image below.
In addition, the "Show in Files" action has been moved to `exm-detail-view`.
<img width="1810" height="1300" alt="image" src="https://github.com/user-attachments/assets/4b7a5cb1-06a6-4cf2-9fc6-82a5fa1c997c" />
